### PR TITLE
🤖 Enhance backend with session management

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer

--- a/backend/app/embedding_context.py
+++ b/backend/app/embedding_context.py
@@ -1,4 +1,22 @@
-# Ce fichier gère le contexte d'embedding pour le backend
-# TODO: Compléter l'implémentation de embedding_context
+"""Simple context manager using in-memory storage."""
 
-# ...existing code...
+from collections import defaultdict
+from typing import List
+
+
+class EmbeddingContext:
+    """Store recent messages for each session."""
+
+    def __init__(self, max_messages: int = 10) -> None:
+        self.max_messages = max_messages
+        self._data: dict[int, List[str]] = defaultdict(list)
+
+    def add_message(self, session_id: int, text: str) -> None:
+        msgs = self._data[session_id]
+        msgs.append(text)
+        if len(msgs) > self.max_messages:
+            del msgs[0]
+
+    def get_recent_context(self, session_id: int, count: int = 5) -> str:
+        msgs = self._data.get(session_id, [])
+        return "\n".join(msgs[-count:])

--- a/backend/app/img_gen_server.py
+++ b/backend/app/img_gen_server.py
@@ -1,4 +1,21 @@
-# Ce fichier gère la génération d'images pour le backend
-# TODO: Compléter l'implémentation de img_gen_server
+"""Wrapper around the Ollama image generation endpoint."""
 
-# ...existing code...
+from __future__ import annotations
+
+import os
+import requests
+
+OLLAMA_IMAGE_MODEL = os.environ.get("OLLAMA_IMAGE_MODEL", "llava")
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "ollama")
+OLLAMA_PORT = os.environ.get("OLLAMA_PORT", "11434")
+BASE_URL = f"http://{OLLAMA_HOST}:{OLLAMA_PORT}/api"
+
+
+def generate_image(prompt: str) -> dict:
+    """Generate an image using the configured Ollama model."""
+    resp = requests.post(
+        f"{BASE_URL}/generate-image",
+        json={"model": OLLAMA_IMAGE_MODEL, "prompt": prompt},
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/backend/tests/test_root.py
+++ b/backend/tests/test_root.py
@@ -12,3 +12,13 @@ def test_read_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json()["message"] == "Backend FastAPI fonctionne !"
+
+
+def test_create_user_and_session():
+    user_resp = client.post("/users", json={"username": "alice"})
+    assert user_resp.status_code == 200
+    user_id = user_resp.json()["user_id"]
+
+    sess_resp = client.post("/sessions", json={"user_id": user_id})
+    assert sess_resp.status_code == 200
+    assert "session_id" in sess_resp.json()


### PR DESCRIPTION
## Summary
- add package initializer
- implement in-memory context store and image generation helper
- extend API with user and session endpoints
- persist messages in context store
- test user and session creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7be1261c832e97fac13359af4d5b