### PR TITLE
Add MCP listing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Ce projet combine un backend FastAPI orchestré avec Docker, un service Ollama p
 
 ## Fonctionnalités principales
 - **Backend FastAPI** : Fournit des endpoints pour la génération de texte et d'images, communique avec Ollama via HTTP.
+- **Support du Model Context Protocol (MCP)** : Endpoint `/mcp` compatible JSON-RPC pour initialiser un client et lister prompts, ressources et outils disponibles.
 - **Ollama** : Service LLM (ex : llama2, tinyllama) lancé dans un conteneur dédié, téléchargement automatique du modèle au démarrage, support GPU NVIDIA.
 - **Godot** : Client graphique, dialogue avec le backend pour afficher les réponses du LLM.
 - **Orchestration Docker Compose** : Démarrage, arrêt, persistance des modèles, rebuild, etc.
@@ -72,6 +73,17 @@ Ou directement :
 ```zsh
 make api_call
 ```
+
+## Utilisation du Model Context Protocol
+Un endpoint `/mcp` répond au format JSON-RPC 2.0.
+Les principales méthodes disponibles sont :
+
+- `initialize` : négocie la version du protocole et renvoie les capacités du serveur.
+- `prompts/list` : obtient la liste des prompts fournis.
+- `resources/list` : renvoie les ressources disponibles.
+- `tools/list` : liste les outils exposés par le serveur.
+
+Ces méthodes facilitent l'intégration d'applications agentiques compatibles MCP.
 
 ## Personnalisation
 - Modifiez le modèle LLM utilisé en changeant la variable d'environnement `OLLAMA_TEXT_MODEL` dans `docker-compose.yml` ou le `Modelfile`.

--- a/backend/app/backend_server.py
+++ b/backend/app/backend_server.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from .embedding_context import EmbeddingContext
 from .img_gen_server import generate_image as ollama_generate_image
+from .mcp import router as mcp_router
 
 from . import models
 from .database import Base, engine, get_db
@@ -18,6 +19,7 @@ from .database import Base, engine, get_db
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+app.include_router(mcp_router)
 
 # Global context manager for storing recent messages
 context_store = EmbeddingContext()

--- a/backend/app/mcp.py
+++ b/backend/app/mcp.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+PROMPTS = [
+    {"name": "greeting", "description": "Simple greeting prompt"},
+]
+
+RESOURCES = [
+    {"uri": "resource://example.txt", "name": "Example Resource"},
+]
+
+TOOLS = [
+    {
+        "name": "echo",
+        "description": "Echo text back",
+        "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}},
+    }
+]
+
+router = APIRouter()
+
+
+class JSONRPCRequest(BaseModel):
+    jsonrpc: str
+    method: str
+    params: Optional[Dict[str, Any]] = None
+    id: Optional[int | str] = None
+
+
+@router.post("/mcp")
+async def handle_mcp(request: JSONRPCRequest):
+    if request.jsonrpc != "2.0":
+        raise HTTPException(status_code=400, detail="Unsupported JSON-RPC version")
+
+    if request.method == "initialize":
+        protocol_version = None
+        if request.params:
+            protocol_version = request.params.get("protocolVersion")
+        result = {
+            "protocolVersion": protocol_version or "2024-11-05",
+            "capabilities": {
+                "logging": {},
+                "prompts": {"listChanged": True},
+                "resources": {"listChanged": True},
+                "tools": {"listChanged": True},
+            },
+            "serverInfo": {"name": "GodotAI", "version": "0.1.0"},
+            "instructions": "Welcome to the MCP server",
+        }
+        return JSONResponse({"jsonrpc": "2.0", "id": request.id, "result": result})
+
+    if request.method == "prompts/list":
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": request.id, "result": {"prompts": PROMPTS}}
+        )
+
+    if request.method == "resources/list":
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": request.id, "result": {"resources": RESOURCES}}
+        )
+
+    if request.method == "tools/list":
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": request.id, "result": {"tools": TOOLS}}
+        )
+
+    raise HTTPException(status_code=404, detail="Method not supported")

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from backend.app.backend_server import app
+
+client = TestClient(app)
+
+
+def test_initialize():
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "TestClient", "version": "0.0.1"},
+        },
+    }
+    resp = client.post("/mcp", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["jsonrpc"] == "2.0"
+    assert data["id"] == 1
+    assert "result" in data
+
+
+def _rpc(method: str):
+    return {"jsonrpc": "2.0", "id": 99, "method": method}
+
+
+def test_prompts_list():
+    resp = client.post("/mcp", json=_rpc("prompts/list"))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "prompts" in data["result"]
+
+
+def test_resources_list():
+    resp = client.post("/mcp", json=_rpc("resources/list"))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "resources" in data["result"]
+
+
+def test_tools_list():
+    resp = client.post("/mcp", json=_rpc("tools/list"))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "tools" in data["result"]

--- a/backend/tests/test_root.py
+++ b/backend/tests/test_root.py
@@ -4,6 +4,7 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from backend.app.backend_server import app
+import uuid
 
 client = TestClient(app)
 
@@ -15,7 +16,8 @@ def test_read_root():
 
 
 def test_create_user_and_session():
-    user_resp = client.post("/users", json={"username": "alice"})
+    uname = f"user_{uuid.uuid4().hex[:8]}"
+    user_resp = client.post("/users", json={"username": uname})
     assert user_resp.status_code == 200
     user_id = user_resp.json()["user_id"]
 


### PR DESCRIPTION
## Summary
- implement MCP list endpoints (`prompts`, `resources`, `tools`)
- test new MCP features and update user tests
- mention MCP support in the README

## Testing
- `black backend/app backend/tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7d4570e4832e9c045ba1c89437c9