### PR TITLE
🤖 Add MkDocs documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ mono_crash.*.json
 __pycache__/
 *.pyc
 *.db
+site/

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,11 @@ clean:
 api_call:
 	@echo "🧠  Lancement d’un appel API Godot en mode headless..."
 	@~/Téléchargements/Godot_v4.4.1-stable_linux.x86_64 --headless --path godot/ --script scripts/ApiCallHeadless.gd
+
+## 📚 Lance le serveur MkDocs en local
+docs-serve:
+	mkdocs serve
+
+## 🚀 Déploie la documentation sur GitHub Pages
+docs-deploy:
+	mkdocs gh-deploy --clean

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Ce projet combine un backend FastAPI orchestré avec Docker, un service Ollama pour la génération de texte (LLM), et un client Godot pour l'interface utilisateur. L'ensemble permet de créer des expériences interactives avec des modèles de langage avancés, le tout automatisé et prêt à l'emploi.
 
+Retrouvez la documentation complète sur [GitHub Pages](https://example.github.io/GodotAI/).
+
+
 ## Fonctionnalités principales
 - **Backend FastAPI** : Fournit des endpoints pour la génération de texte et d'images, communique avec Ollama via HTTP.
 - **Ollama** : Service LLM (ex : llama2, tinyllama) lancé dans un conteneur dédié, téléchargement automatique du modèle au démarrage, support GPU NVIDIA.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# GodotAI
+
+Bienvenue sur la documentation du projet **GodotAI**. Ce site couvre l'installation rapide et les principales commandes pour démarrer.
+
+- [Installation rapide](installation.md)
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,17 @@
+# Installation rapide
+
+1. **Cloner le dépôt**
+```bash
+git clone <repo_url>
+cd godot_ai
+```
+
+2. **Lancer les services**
+```bash
+make up
+```
+
+3. **Arrêter les services**
+```bash
+make down
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: GodotAI
+site_url: https://example.github.io/GodotAI
+theme: readthedocs
+nav:
+  - Accueil: index.md
+  - Installation: installation.md


### PR DESCRIPTION
## Summary
- add mkdocs config
- provide docs with install instructions
- link docs from README
- add make commands to serve or deploy docs
- ignore built site directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7f7def18832e9e14c2aff4c9205f