### PR TITLE
Add new image model container

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ GodotAI combine plusieurs briques pour créer une expérience de jeu pilotée pa
 - Permet de tester rapidement l'API en mode éditeur ou en ligne de commande.
 
 ### 4. 🐳 Docker Compose
-- Orchestration des services `ollama` et `backend`.
-- Monte un volume `ollama_models` pour conserver les modèles téléchargés.
-- Les variables d'environnement (GPU, nom du modèle, etc.) sont configurables dans `docker-compose.yml`.
+- Orchestration des services `ollama`, `ollama_image` et `backend`.
+- Monte des volumes `ollama_models` et `ollama_image_models` pour conserver les modèles téléchargés.
+- Les variables d'environnement (GPU, nom des modèles, etc.) sont configurables dans `docker-compose.yml`.
 
 ### 5. 📚 MkDocs
 - La documentation vit dans le dossier `docs/` et peut être servie via `mkdocs serve`.

--- a/backend/app/backend_server.py
+++ b/backend/app/backend_server.py
@@ -64,10 +64,15 @@ class CreateSessionRequest(BaseModel):
 
 # Utilitaire pour choisir le modèle Ollama
 OLLAMA_TEXT_MODEL = os.environ.get("OLLAMA_TEXT_MODEL", "llama2")
-OLLAMA_IMAGE_MODEL = os.environ.get("OLLAMA_IMAGE_MODEL", "llava")
-OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "ollama")
-OLLAMA_PORT = os.environ.get("OLLAMA_PORT", "11434")
-OLLAMA_BASE_URL = f"http://{OLLAMA_HOST}:{OLLAMA_PORT}/api"
+OLLAMA_IMAGE_MODEL = os.environ.get("OLLAMA_IMAGE_MODEL", "llava:7b")
+
+OLLAMA_TEXT_HOST = os.environ.get("OLLAMA_TEXT_HOST", "ollama")
+OLLAMA_TEXT_PORT = os.environ.get("OLLAMA_TEXT_PORT", "11434")
+OLLAMA_IMAGE_HOST = os.environ.get("OLLAMA_IMAGE_HOST", "ollama_image")
+OLLAMA_IMAGE_PORT = os.environ.get("OLLAMA_IMAGE_PORT", "11435")
+
+OLLAMA_TEXT_BASE_URL = f"http://{OLLAMA_TEXT_HOST}:{OLLAMA_TEXT_PORT}/api"
+OLLAMA_IMAGE_BASE_URL = f"http://{OLLAMA_IMAGE_HOST}:{OLLAMA_IMAGE_PORT}/api"
 
 
 # Endpoint pour générer du texte via Ollama
@@ -80,7 +85,7 @@ def gen_text_get():
 def gen_text(req: ContextRequest):
     try:
         response = requests.post(
-            f"{OLLAMA_BASE_URL}/generate",
+            f"{OLLAMA_TEXT_BASE_URL}/generate",
             json={"model": OLLAMA_TEXT_MODEL, "prompt": req.context},
         )
         response.raise_for_status()
@@ -115,7 +120,7 @@ def gen_image(req: ImageRequest):
 @app.get("/list_models")
 def list_models():
     try:
-        response = requests.get(f"{OLLAMA_BASE_URL}/tags")
+        response = requests.get(f"{OLLAMA_TEXT_BASE_URL}/tags")
         response.raise_for_status()
         data = response.json()
         # Retourne la liste des modèles installés
@@ -174,7 +179,7 @@ def generate_text(req: GenerateTextRequest, db: Session = Depends(get_db)):
 
     try:
         response = requests.post(
-            f"{OLLAMA_BASE_URL}/generate",
+            f"{OLLAMA_TEXT_BASE_URL}/generate",
             json={"model": OLLAMA_TEXT_MODEL, "prompt": context},
         )
         response.raise_for_status()

--- a/backend/app/img_gen_server.py
+++ b/backend/app/img_gen_server.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import os
 import requests
 
-OLLAMA_IMAGE_MODEL = os.environ.get("OLLAMA_IMAGE_MODEL", "llava")
-OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "ollama")
-OLLAMA_PORT = os.environ.get("OLLAMA_PORT", "11434")
-BASE_URL = f"http://{OLLAMA_HOST}:{OLLAMA_PORT}/api"
+OLLAMA_IMAGE_MODEL = os.environ.get("OLLAMA_IMAGE_MODEL", "llava:7b")
+OLLAMA_IMAGE_HOST = os.environ.get("OLLAMA_IMAGE_HOST", "ollama_image")
+OLLAMA_IMAGE_PORT = os.environ.get("OLLAMA_IMAGE_PORT", "11435")
+BASE_URL = f"http://{OLLAMA_IMAGE_HOST}:{OLLAMA_IMAGE_PORT}/api"
 
 
 def generate_image(prompt: str) -> dict:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,25 @@ services:
       - OLLAMA_LLM_LIBRARY=cuda
     restart: unless-stopped
     gpus: all
-    
+
+  ollama_image:
+    build:
+      context: .
+      dockerfile: Dockerfile.ollama
+    container_name: ollama_image
+    ports:
+      - "11435:11434"
+    volumes:
+      - ollama_image_models:/root/.ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+      - OLLAMA_TEXT_MODEL=llava:7b
+      - NVIDIA_VISIBLE_DEVICES=all
+      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_LLM_LIBRARY=cuda
+    restart: unless-stopped
+    gpus: all
+
 volumes:
   ollama_models:
+  ollama_image_models:

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -6,13 +6,14 @@ Cette page décrit les principaux composants utilisés dans **GodotAI** et renvo
 Le backend HTTP est construit avec [FastAPI](https://fastapi.tiangolo.com/). Il expose plusieurs routes pour communiquer avec le modèle et stocker les messages.
 
 ## 🦙 Ollama
-[Ollama](https://github.com/ollama/ollama) fournit le Large Language Model exécuté dans un conteneur Docker dédié. Les modèles sont téléchargés automatiquement au démarrage.
+[Ollama](https://github.com/ollama/ollama) fournit le Large Language Model exécuté dans un conteneur Docker dédié. Les modèles sont téléchargés automatiquement au démarrage. Un second conteneur `ollama_image` se charge de la génération d'images avec un modèle plus léger.
 
 ## 🎮 Godot
 Le client graphique est développé avec [Godot](https://docs.godotengine.org/en/stable/). Des scripts GDScript appellent l'API pour afficher les réponses dans le jeu.
 
 ## 🐳 Docker Compose
 L'orchestration des services se fait via [Docker Compose](https://docs.docker.com/compose/). Une simple commande `make up` démarre l'ensemble.
+Le fichier Compose définit également un service `ollama_image` dédié à la génération d'images.
 
 ## 📚 MkDocs
 La documentation vit dans le dossier `docs/` et est construite avec [MkDocs](https://www.mkdocs.org/). Vous pouvez lancer `mkdocs serve` pour un aperçu local.


### PR DESCRIPTION
🤖 Adds a dedicated `ollama_image` service for lightweight image generation. Updates backend configuration to use separate hosts for text and image models, and refreshes documentation.

------
https://chatgpt.com/codex/tasks/task_e_6840793b61a8832ea9e479dfb31aeafa