### PR TITLE
🤖 Improve documentation

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,4 @@
+MinAlertLevel = warning
+
+[*]
+BasedOnStyles = Vale

--- a/README.md
+++ b/README.md
@@ -1,78 +1,29 @@
 # 🤖 GodotAI
 
-GodotAI combine plusieurs briques pour créer une expérience de jeu pilotée par un LLM. ✨ Ce README récapitule chaque composant et explique comment lancer le projet.
+GodotAI permet de piloter un mini-jeu Godot avec un modèle de langage local, le tout orchestré par Docker.
 
-## 🧩 Composants
+## 🚀 Démarrage rapide
+1. Installez [Docker](https://docs.docker.com/get-docker/) et [Git](https://git-scm.com/).
+2. Clonez le dépôt :
+   ```bash
+   git clone <repo_url>
+   cd godot_ai
+   ```
+3. Lancez les services :
+   ```bash
+   make up
+   ```
+   Les modèles sont téléchargés au premier lancement.
+4. (Facultatif) Ouvrez Godot :
+   ```bash
+   make run-godot
+   ```
+5. Stoppez le tout :
+   ```bash
+   make down
+   ```
 
-### 1. ⚡ FastAPI
-- Sert d'API REST.
-- Expose des routes pour générer du texte et des images via Ollama.
-- Implémente le Model Context Protocol (MCP) pour décrire prompts, outils et ressources.
-- Stocke utilisateurs, sessions et messages avec SQLAlchemy dans `game.db`.
-- Conserve un contexte récent en mémoire grâce à `EmbeddingContext`.
-
-### 2. 🦙 Ollama
-- Service LLM exécuté dans un conteneur dédié.
-- Le Dockerfile personnalise l'image officielle et lance `entrypoint_ollama.sh` pour télécharger automatiquement le modèle choisi (`OLLAMA_TEXT_MODEL`).
-- Support GPU via NVIDIA Container Toolkit.
-- Les paramètres par défaut du modèle sont définis dans `Modelfile`.
-
-### 3. 🎮 Godot
-- Client graphique basé sur Godot 4.
-- Les scripts `ChatUI.gd` et `ApiCallHeadless.gd` communiquent avec le backend par HTTP.
-- Permet de tester rapidement l'API en mode éditeur ou en ligne de commande.
-
-### 4. 🐳 Docker Compose
-- Orchestration des services `ollama`, `stablediffusion` et `backend`.
-- Monte des volumes `ollama_models`, `sd_models` et `sd_outputs` pour conserver modèles et résultats.
-- Les variables d'environnement (GPU, noms et ports des modèles...) sont centralisées dans `.env` et injectées par `docker-compose.yml`.
-
-### 5. 📚 MkDocs
-- La documentation vit dans le dossier `docs/` et peut être servie via `mkdocs serve`.
-- Le déploiement sur GitHub Pages est géré par `mkdocs gh-deploy` (voir Makefile).
-
-## 🚀 Lancer le projet
-```bash
-# 1. cloner le dépôt
-$ git clone <repo_url>
-$ cd godot_ai
-
-# 2. démarrer Ollama et l'API
-$ make up
-
-# 3. ouvrir le client Godot (facultatif)
-$ make run-godot
-```
-- Ollama écoute sur `localhost:11434` et télécharge le modèle au premier démarrage.
-- Le backend est disponible sur `localhost:8000` (voir `backend/app/backend_server.py`).
-
-Pour arrêter les services :
-```bash
-$ make down
-```
-
-## 📝 Model Context Protocol
-L'endpoint `/mcp` parle JSON-RPC 2.0. Il permet :
-- d'initialiser un client (`initialize`),
-- de lister prompts, ressources et outils disponibles.
-
-Ceci simplifie l'intégration d'agents compatibles MCP.
-
-## 🎨 Personnalisation
-- Tous les modèles et ports sont configurables dans `.env` (`OLLAMA_TEXT_MODEL`, `OLLAMA_IMAGE_MODEL`, `OLLAMA_TEXT_PORT`, etc.).
-- Modifiez le prompt système dans `Modelfile`.
-- Ajoutez vos propres routes dans `backend/app` ou scripts dans `godot/`.
+L'API répond sur `localhost:8000`.
 
 ## 📚 Documentation
-Une doc synthétique est disponible dans `docs/`. Servez-la en local avec :
-```bash
-mkdocs serve
-```
-ou déployez-la via :
-```bash
-mkdocs gh-deploy --clean
-```
-
----
-
-Pour toute question, consultez les logs Docker ou ouvrez une issue sur le dépôt.
+Plus d'informations dans le dossier `docs/` ou sur la [documentation en ligne](https://example.github.io/GodotAI).

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -1,0 +1,14 @@
+# 🐳 Docker Compose
+
+Docker Compose orchestre les différents conteneurs du projet. Toutes les commandes sont encapsulées dans le `Makefile`.
+
+Commandes utiles :
+```bash
+# Démarrer les services en arrière-plan
+make up
+
+# Arrêter l'ensemble
+make down
+```
+
+- [Guide Docker Compose](https://docs.docker.com/compose/)

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -1,0 +1,17 @@
+# ⚡ FastAPI
+
+FastAPI est un framework Web moderne et asynchrone pour Python.
+Dans **GodotAI**, il expose les routes HTTP utilisées par le client Godot et gère la base SQLite.
+
+## Exemple minimal
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/ping")
+def ping():
+    return {"message": "pong"}
+```
+
+- [Documentation officielle](https://fastapi.tiangolo.com/)

--- a/docs/godot.md
+++ b/docs/godot.md
@@ -1,0 +1,11 @@
+# 🎮 Godot
+
+Godot fournit l'interface graphique du mini-jeu et communique avec l'API Python.
+Les scripts GDScript appellent l'endpoint `/generate-text` pour afficher les réponses du modèle.
+
+Pour lancer l'éditeur :
+```bash
+make run-godot
+```
+
+- [Documentation Godot](https://docs.godotengine.org/en/stable/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,8 @@
 # 🤖 GodotAI
 
-## Articles
-===========
-Bienvenue sur la documentation du projet **GodotAI**. 🚀 Ce site couvre l'installation rapide et les principales commandes pour démarrer.
+Bienvenue ! Cette documentation vous guide à travers l'installation et l'utilisation du projet.
 
-- [📥 Installation rapide](installation.md)
-- [🛠️ Stack logiciel](stack.md)
-
-Vous pouvez également explorer le [notebook d'exemple](notebooks/api_example.ipynb) pour tester l'API depuis Python.
+## Sommaire
+- [🚀 Installation](installation.md)
+- [🧩 La stack](stack.md)
+- [💻 Exemple de notebook](notebooks/api_example.ipynb)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,17 +1,21 @@
-# 🚀 Installation rapide
+# 🚀 Installation pas à pas
 
-1. 📥 **Cloner le dépôt**
-```bash
-git clone <repo_url>
-cd godot_ai
-```
-
-2. ⚙️ **Lancer les services**
-```bash
-make up
-```
-
-3. 🛑 **Arrêter les services**
-```bash
-make down
-```
+1. Installez [Docker](https://docs.docker.com/get-docker/) et [Git](https://git-scm.com/).
+2. Clonez le dépôt :
+   ```bash
+   git clone <repo_url>
+   cd godot_ai
+   ```
+3. Démarrez les services :
+   ```bash
+   make up
+   ```
+   Les modèles Ollama se téléchargent automatiquement.
+4. (Optionnel) Lancez Godot :
+   ```bash
+   make run-godot
+   ```
+5. Coupez les conteneurs :
+   ```bash
+   make down
+   ```

--- a/docs/mkdocs.md
+++ b/docs/mkdocs.md
@@ -1,0 +1,11 @@
+# 📚 MkDocs
+
+La documentation est générée via MkDocs et le thème Material. Toutes les pages Markdown du dossier `docs/` sont transformées en site statique.
+
+Pour tester en local :
+```bash
+pip install mkdocs mkdocs-material
+mkdocs serve
+```
+
+- [Site de MkDocs](https://www.mkdocs.org/)

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -1,0 +1,11 @@
+# 🦙 Ollama
+
+Ollama lance le modèle de langage à l'intérieur d'un conteneur Docker.
+Au premier démarrage, l'image téléchargée récupère automatiquement le modèle choisi.
+
+Exemple d'exécution manuelle :
+```bash
+docker run -p 11434:11434 ollama/ollama:latest serve
+```
+
+- [Projet sur GitHub](https://github.com/ollama/ollama)

--- a/docs/stable-diffusion.md
+++ b/docs/stable-diffusion.md
@@ -1,0 +1,12 @@
+# 🎨 Stable Diffusion
+
+Le service d'images fonctionne grâce à Stable Diffusion. Il s'exécute lui aussi dans un conteneur dédié.
+
+Vous pouvez générer une image directement via l'API :
+```bash
+curl -X POST http://localhost:8000/generate-image \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "un village médiéval"}' -o output.png
+```
+
+- [Dépôt officiel](https://github.com/Stability-AI/stablediffusion)

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -1,27 +1,28 @@
-# ⚙️ Stack logiciel
+# 🧩 Comprendre la stack
 
-Cette page décrit les principaux composants utilisés dans **GodotAI** et renvoie vers leur documentation officielle.
+Cette page présente brièvement l'architecture générale avant de détailler chaque composant.
 
-## ⚡ FastAPI
-Le backend HTTP est construit avec [FastAPI](https://fastapi.tiangolo.com/). Il expose plusieurs routes pour communiquer avec le modèle et stocker les messages.
+```text
+[Utilisateur]
+     |
+   Godot 🎮
+     |
+  FastAPI ⚡
+   /   \
+Ollama 🦙  Stable Diffusion 🎨
+     \
+     SQLite 📂
+```
 
-## 🦙 Ollama
-[Ollama](https://github.com/ollama/ollama) fournit le Large Language Model exécuté dans un conteneur Docker dédié. Les modèles sont téléchargés automatiquement au démarrage. Le conteneur `stablediffusion` utilise désormais Stable Diffusion pour la génération d'images.
+## Pages détaillées
+- [⚡ FastAPI](fastapi.md)
+- [🦙 Ollama](ollama.md)
+- [🎨 Stable Diffusion](stable-diffusion.md)
+- [🎮 Godot](godot.md)
+- [🐳 Docker Compose](docker-compose.md)
+- [📚 MkDocs](mkdocs.md)
 
-## 🎮 Godot
-Le client graphique est développé avec [Godot](https://docs.godotengine.org/en/stable/). Des scripts GDScript appellent l'API pour afficher les réponses dans le jeu.
-
-## 🐳 Docker Compose
-L'orchestration des services se fait via [Docker Compose](https://docs.docker.com/compose/). Une simple commande `make up` démarre l'ensemble.
-Le fichier Compose définit également un service `stablediffusion` basé sur Stable Diffusion pour la génération d'images.
-Toutes les options de modèles et de ports sont déclarées dans le fichier `.env` et reprises par Compose.
-
-## 📚 MkDocs
-La documentation vit dans le dossier `docs/` et est construite avec [MkDocs](https://www.mkdocs.org/). Vous pouvez lancer `mkdocs serve` pour un aperçu local.
-
-## 📜 Exemple d'appel API
-Ci-dessous un petit exemple en Python pour générer du texte via l'API :
-
+## Exemple d'appel API
 ```python
 import requests
 
@@ -33,5 +34,5 @@ resp = requests.post(
 print(resp.json())
 ```
 
-## 📓 Notebook Jupyter
-Un notebook prêt à l'emploi est disponible dans [notebooks/api_example.ipynb](notebooks/api_example.ipynb) pour tester ces appels de manière interactive.
+## Notebook Jupyter
+Essayez le notebook [notebooks/api_example.ipynb](notebooks/api_example.ipynb) pour tester ces appels interactivement.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,4 +5,11 @@ theme:
 nav:
   - Accueil: index.md
   - Installation: installation.md
-  - Stack: stack.md
+  - Stack:
+      - Aperçu: stack.md
+      - FastAPI: fastapi.md
+      - Ollama: ollama.md
+      - Stable Diffusion: stable-diffusion.md
+      - Godot: godot.md
+      - Docker Compose: docker-compose.md
+      - MkDocs: mkdocs.md


### PR DESCRIPTION
## Summary
- split each technology into its own page
- expand stack overview with links to new pages
- clarify installation and index docs
- update MkDocs navigation
- add Vale configuration for style checking

## Testing
- `pip install mkdocs mkdocs-material -q`
- `mkdocs build -q`
- `vale docs/*.md README.md` *(fails: 122 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684098868910832eb5b7e57528058028