### PR TITLE
Fix Makefile Godot path

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,6 @@ OLLAMA_TEXT_PORT=11434
 OLLAMA_IMAGE_MODEL=stable-diffusion
 OLLAMA_IMAGE_HOST=stablediffusion
 OLLAMA_IMAGE_PORT=7860
+
+# Path to the Godot executable
+GODOT_PATH=godot4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
-# Makefile 🧙‍♂️ pour gérer le projet RPG LLM Godot avec activation automatique du venv
+	# Makefile 🧙‍♂️ pour gérer le projet RPG LLM Godot avec activation automatique du venv
 
 .DEFAULT_GOAL := help
+
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
+
+GODOT_PATH ?= godot4
 
 ## 📘 Affiche cette aide
 help:
@@ -24,7 +31,7 @@ rebuild:
 ## 🎮 Lance le projet Godot (modifie selon ton chemin d'accès)
 run-godot:
 	@echo "\033[1;36m🎮 Ouverture de Godot...\033[0m"
-	godot4 --editor godot/project.godot
+	$(GODOT_PATH) --editor godot/project.godot
 
 ## 🧹 Supprime fichiers temporaires / cache
 clean:

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ GodotAI permet de piloter un mini-jeu Godot avec un modèle de langage local, le
 L'API répond sur `localhost:8000`.
 
 ## 📚 Documentation
-Plus d'informations dans le dossier `docs/` ou sur la [documentation en ligne](https://example.github.io/GodotAI).
+Plus d'informations dans le dossier `docs/` ou sur la [documentation en ligne](https://ezpk.github.io/GodotAI).


### PR DESCRIPTION
🤖 Update the Godot path handling and fix docs link

## Summary
- load `.env` in the Makefile and use `GODOT_PATH` for `run-godot`
- document that the Godot path can be set via `.env`
- fix the README link to the online documentation

## Testing
- `make run-godot -n`


------
https://chatgpt.com/codex/tasks/task_e_68409f4ee4f4832e8ec13135b75f21d0