### PR TITLE
🤖 Add unit and E2E tests with documentation

### DIFF
--- a/backend/tests/test_backend_server_endpoints.py
+++ b/backend/tests/test_backend_server_endpoints.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+import os
+import sys
+from unittest.mock import Mock
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from backend.app.backend_server import app
+
+client = TestClient(app)
+
+
+def test_gen_text(monkeypatch):
+    def fake_post(url, json):
+        assert "generate" in url
+        assert json["model"]
+        assert json["prompt"] == "context"
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        resp.json.return_value = {"response": "text"}
+        return resp
+
+    monkeypatch.setattr("backend.app.backend_server.requests.post", fake_post)
+
+    resp = client.post("/gen_text", json={"context": "context"})
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "text"}
+
+
+def test_list_models(monkeypatch):
+    mock_resp = Mock()
+    mock_resp.raise_for_status = Mock()
+    mock_resp.json.return_value = {"models": [{"name": "foo"}, {"name": "bar"}]}
+
+    def fake_get(url):
+        assert "tags" in url
+        return mock_resp
+
+    monkeypatch.setattr("backend.app.backend_server.requests.get", fake_get)
+
+    resp = client.get("/list_models")
+    assert resp.status_code == 200
+    assert resp.json() == {"models": ["foo", "bar"]}
+
+
+def test_generate_image(monkeypatch):
+    monkeypatch.setattr(
+        "backend.app.backend_server.ollama_generate_image",
+        lambda prompt: {"image": "imgdata"},
+    )
+
+    resp = client.post("/gen_image", json={"prompt": "hello"})
+    assert resp.status_code == 200
+    assert resp.json() == {"image": "imgdata"}

--- a/docs/tests-e2e.md
+++ b/docs/tests-e2e.md
@@ -1,0 +1,20 @@
+# 🚦 Tests E2E avec Playwright
+
+Le projet propose également un exemple de test de bout en bout utilisant
+**Playwright**. Ces tests vivent dans le dossier `e2e/`.
+
+Pour installer Playwright et ses dépendances :
+
+```bash
+pip install playwright
+# Optionnel : playwright install
+```
+
+Lancez ensuite les tests E2E avec :
+
+```bash
+pytest e2e
+```
+
+Le script démarre brièvement le serveur FastAPI sur un port local puis effectue
+un appel HTTP via l'API `request` de Playwright.

--- a/docs/tests-unitaires.md
+++ b/docs/tests-unitaires.md
@@ -1,0 +1,20 @@
+# ✅ Tests unitaires
+
+Cette page explique comment lancer les tests unitaires du backend.
+
+Les tests sont écrits avec **pytest** et se trouvent dans le dossier `backend/tests/`.
+Pour exécuter l'ensemble des tests :
+
+```bash
+pytest -q
+```
+
+Les dépendances nécessaires sont listées dans `backend/requirements.txt`.
+Avant de lancer les tests pour la première fois, installez-les avec :
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+Chaque nouvelle fonctionnalité Python doit être accompagnée d'un test
+correspondant dans ce répertoire.

--- a/e2e/test_api_playwright.py
+++ b/e2e/test_api_playwright.py
@@ -1,0 +1,26 @@
+import threading
+import time
+
+import os
+import sys
+import uvicorn
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from backend.app.backend_server import app
+from playwright.sync_api import sync_playwright
+
+
+def _start_server():
+    uvicorn.run(app, host="127.0.0.1", port=8002, log_level="error")
+
+
+def test_root_endpoint():
+    server = threading.Thread(target=_start_server, daemon=True)
+    server.start()
+    time.sleep(1)
+
+    with sync_playwright() as p:
+        request = p.request.new_context(base_url="http://127.0.0.1:8002")
+        resp = request.get("/")
+        assert resp.status == 200
+        assert resp.json()["message"] == "Backend FastAPI fonctionne !"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,3 +13,6 @@ nav:
       - Godot: godot.md
       - Docker Compose: docker-compose.md
       - MkDocs: mkdocs.md
+  - Tests:
+      - Unitaires: tests-unitaires.md
+      - E2E Playwright: tests-e2e.md


### PR DESCRIPTION
## Summary
- add API endpoint tests
- provide basic Playwright E2E example
- document how to run unit and E2E tests
- update documentation navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a327d5ac832e9b7911a67cf5f505