### PR TITLE
🤖 Fix Makefile indentation for make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ help:
 
 ## 🚢 Lancer les services Docker (Ollama + backend) et FastAPI
 up:
-        docker compose up -d
-        @uvicorn backend.app.backend_server:app --reload &
-        @echo "FastAPI launched on http://localhost:8000"
+	docker compose up -d
+	@uvicorn backend.app.backend_server:app --reload &
+	@echo "FastAPI launched on http://localhost:8000"
 
 ## 🛑 Arrêter les services Docker
 down:


### PR DESCRIPTION
## Summary
- use tabs instead of spaces in Makefile rules

## Testing
- `make help`

------
https://chatgpt.com/codex/tasks/task_e_6840aef0efd4832e8b8614f72fd7c1c4