### PR TITLE
🤖 Add universe make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,18 @@ docs-serve:
 ## 🚀 Déploie la documentation sur GitHub Pages
 docs-deploy:
 	mkdocs gh-deploy --clean
+
+## 🪐 Lance tous les tests et génère un log complet
+universe:
+	mkdir -p rapports
+	echo "Running black" > rapports/universe.log
+	black backend/app >> rapports/universe.log 2>&1
+	echo "\nRunning unit tests" >> rapports/universe.log
+	pytest -q >> rapports/universe.log 2>&1
+	echo "\nChecking services" >> rapports/universe.log
+	python utils/test_services.py >> rapports/universe.log 2>&1 || true
+	echo "\nRunning e2e tests" >> rapports/universe.log
+	pytest e2e/test_api_playwright.py -q >> rapports/universe.log 2>&1 || true
+	echo "\nBuilding docs" >> rapports/universe.log
+	mkdocs build >> rapports/universe.log 2>&1
+	@echo "Logs written to rapports/universe.log"

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -6,5 +6,6 @@ Le `Makefile` centralise plusieurs commandes utiles :
 - `make rebuild` recrée les images Docker sans cache ;
 - `make docs-serve` prévisualise la documentation ;
 - `make docs-deploy` la publie sur GitHub Pages.
+- `make universe` exécute tous les tests et génère `rapports/universe.log`.
 
 En résumé, il simplifie le quotidien en évitant de longues lignes de commande.

--- a/rapports/universe.log
+++ b/rapports/universe.log
@@ -1,0 +1,37 @@
+Running black
+All done! ✨ 🍰 ✨
+8 files left unchanged.
+
+Running unit tests
+..............                                                           [100%]
+=============================== warnings summary ===============================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:8
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:8: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+backend/tests/test_root.py::test_create_user_and_session
+  /workspace/GodotAI/backend/tests/../../backend/app/backend_server.py:175: LegacyAPIWarning: The Query.get() method is considered legacy as of the 1.x series of SQLAlchemy and becomes a legacy construct in 2.0. The method is now available as Session.get() (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+    user = db.query(models.User).get(req.user_id)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+14 passed, 2 warnings in 2.30s
+
+Checking services
+FastAPI error: HTTPConnectionPool(host='localhost', port=8000): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f4d895781d0>: Failed to establish a new connection: [Errno 111] Connection refused'))
+Ollama error: 403 Client Error: Forbidden for url: http://ollama:11434/api/tags
+Stable Diffusion error: 403 Client Error: Forbidden for url: http://stablediffusion:7860/sdapi/v1/sd-models
+
+Running e2e tests
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:8
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:8: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 1 warning in 2.02s
+
+Building docs
+INFO    -  Cleaning site directory
+INFO    -  Building documentation to directory: /workspace/GodotAI/site
+INFO    -  Documentation built in 0.47 seconds


### PR DESCRIPTION
## Summary
- add `make universe` to run formatter, tests, service checks and docs build
- document new command
- include sample log output

## Testing
- `black backend/app`
- `pytest -q`
- `mkdocs build`
- `make universe`

------
https://chatgpt.com/codex/tasks/task_e_6840b26bdcfc832ea50fdc413afdba59