### PR TITLE
🤖 Ensure SQLite file and log tests

### DIFF
--- a/.env
+++ b/.env
@@ -8,3 +8,4 @@ OLLAMA_IMAGE_PORT=7860
 
 # Path to the Godot executable
 GODOT_PATH=./Godot_v4.x86_64
+DATABASE_URL=sqlite:///./data/game.db

--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,15 @@ docs-deploy:
 
 ## 🪐 Lance tous les tests et génère un log complet
 universe:
-	mkdir -p rapports
-	echo "Running black" > rapports/universe.log
-	black backend/app >> rapports/universe.log 2>&1
-	echo "\nRunning unit tests" >> rapports/universe.log
-	pytest -q >> rapports/universe.log 2>&1
-	echo "\nChecking services" >> rapports/universe.log
-	python utils/test_services.py >> rapports/universe.log 2>&1 || true
-	echo "\nRunning e2e tests" >> rapports/universe.log
-	pytest e2e/test_api_playwright.py -q >> rapports/universe.log 2>&1 || true
-	echo "\nBuilding docs" >> rapports/universe.log
-	mkdocs build >> rapports/universe.log 2>&1
+	@mkdir -p rapports
+	@echo "Running black" > rapports/universe.log
+	@black backend/app >> rapports/universe.log 2>&1
+	@echo "\nRunning unit tests" >> rapports/universe.log
+	@pytest -q >> rapports/universe.log 2>&1
+	@echo "\nChecking services" >> rapports/universe.log
+	@python utils/test_services.py >> rapports/universe.log 2>&1 || true
+	@echo "\nRunning e2e tests" >> rapports/universe.log
+	@pytest e2e/test_api_playwright.py -q >> rapports/universe.log 2>&1 || true
+	@echo "\nBuilding docs" >> rapports/universe.log
+	@mkdocs build >> rapports/universe.log 2>&1
 	@echo "Logs written to rapports/universe.log"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -2,7 +2,12 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./game.db")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./data/game.db")
+
+if DATABASE_URL.startswith("sqlite"):
+    # Ensure directory exists for SQLite file
+    db_path = DATABASE_URL.replace("sqlite:///", "")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
 
 connect_args = {}
 if DATABASE_URL.startswith("sqlite"):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,9 @@ uvicorn>=0.15.0,<0.16.0
 python-multipart>=0.0.5,<0.1.0
 requests>=2.26.0,<3.0.0
 
+python-dotenv
+playwright
+
 SQLAlchemy>=1.4
 psycopg2-binary>=2.9
 httpx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     volumes:
       - ./backend:/app/backend
       - ./utils:/app/utils
-      - ./game.db:/app/game.db
+      - ./data:/app/data
     env_file: .env
     depends_on:
       - ollama


### PR DESCRIPTION
## Summary
- mount data directory in docker-compose for DB
- default DATABASE_URL to data folder and create directory
- log `make universe` output silently
- track data folder
- install python-dotenv and playwright
- add env var for DATABASE_URL

## Testing
- `black backend/app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b80e102c832e98ec12d8b1ead5fa