### PR TITLE
🤖 Update README doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 GodotAI combine Godot, FastAPI et Ollama pour expérimenter localement l'intelligence artificielle dans un mini-jeu. Tout fonctionne dans des conteneurs Docker pour une mise en route rapide.
 
-👉 Consultez la [documentation complète](docs/index.md) pour suivre le tutoriel de prise en main et découvrir les guides, la référence et les explications détaillées.
+👉 Consultez la [documentation complète](https://ezpk.github.io/GodotAI/) pour suivre le tutoriel de prise en main et découvrir les guides, la référence et les explications détaillées.


### PR DESCRIPTION
## Summary
- correct the documentation URL in README

## Testing
- `black backend/app`
- `pytest -q`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6840d3136634832eb25e3daf0f56471e