### PR TITLE
🤖 Add mermaid diagrams for tech pages

### DIFF
--- a/docs/explications/docker-compose.md
+++ b/docs/explications/docker-compose.md
@@ -3,6 +3,13 @@
 Docker Compose est l'outil qui lance plusieurs conteneurs Docker en une seule commande.
 Le fichier `docker-compose.yml` définit trois services : **fastapi**, **ollama** et **stablediffusion**.
 
+```mermaid
+flowchart LR
+    DC[Docker Compose] --> F(fastapi)
+    DC --> O(ollama)
+    DC --> SD(stablediffusion)
+```
+
 Pour simplifier la vie du développeur, toutes les commandes utiles sont regroupées dans le `Makefile`.
 
 Commandes utiles :

--- a/docs/explications/fastapi.md
+++ b/docs/explications/fastapi.md
@@ -9,6 +9,14 @@ routes appelées par Godot, dialogue avec Ollama pour produire du texte et
 déclenche la génération d'images via Stable Diffusion. Il stocke aussi les
 informations de partie dans SQLite.
 
+```mermaid
+flowchart LR
+    G[Godot] --> F(FastAPI)
+    F --> O[Ollama]
+    F --> SD[Stable Diffusion]
+    F --> DB[(SQLite)]
+```
+
 ## Exemple minimal
 ```python
 from fastapi import FastAPI

--- a/docs/explications/godot.md
+++ b/docs/explications/godot.md
@@ -7,6 +7,17 @@ Les scripts GDScript appellent l'endpoint `/generate-text` pour afficher les ré
 Quand le joueur effectue une action, ces scripts envoient la requête à FastAPI
 qui renvoie le texte généré par Ollama.
 
+```mermaid
+sequenceDiagram
+    participant P as Joueur
+    participant G as Godot
+    participant A as FastAPI
+    P->>G: action
+    G->>A: requête
+    A-->>G: réponse
+    G-->>P: affichage
+```
+
 Pour lancer l'éditeur :
 ```bash
 make run-godot

--- a/docs/explications/mkdocs.md
+++ b/docs/explications/mkdocs.md
@@ -4,6 +4,12 @@ MkDocs transforme les fichiers Markdown du dossier `docs/` en un site statique p
 
 La configuration active également le plugin [Mermaid](https://github.com/fralau/mkdocs-mermaid2-plugin) pour intégrer des schémas.
 
+```mermaid
+flowchart LR
+    M[Markdown] --> MK(MkDocs)
+    MK --> HTML[Site statique]
+```
+
 Pour tester en local :
 ```bash
 make install

--- a/docs/explications/ollama.md
+++ b/docs/explications/ollama.md
@@ -19,6 +19,12 @@ Le fichier `Modelfile` à la racine du dépôt indique quel modèle charger. Fas
 lui envoie les requêtes de l'utilisateur pour obtenir une réponse adaptée à la
 partie en cours.
 
+```mermaid
+flowchart LR
+    A(FastAPI) -- requête --> O(Ollama)
+    O -- réponse --> A
+```
+
 Exemple d'exécution manuelle :
 ```bash
 docker run -p 11434:11434 ollama/ollama:latest serve

--- a/docs/explications/stable-diffusion.md
+++ b/docs/explications/stable-diffusion.md
@@ -11,6 +11,12 @@ téléchargés avant que l'interface WebUI ne se lance.
 
 FastAPI lui transmet vos invites afin d'illustrer certaines scènes du jeu.
 
+```mermaid
+flowchart LR
+    A(FastAPI) -- prompt --> SD[Stable Diffusion]
+    SD -- image --> A
+```
+
 Vous pouvez générer une image directement via l'API :
 ```bash
 curl -X POST http://localhost:8000/generate-image \


### PR DESCRIPTION
## Summary
- illustrate Docker Compose usage with a flowchart
- show FastAPI role in the stack
- depict Godot request cycle
- visualize MkDocs site generation
- add Ollama interaction diagram
- include Stable Diffusion workflow

## Testing
- `black backend/app`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6840db9cb5f8832ea027d4f536ea7ff2