### PR TITLE
🤖 Update repo link in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Bienvenue sur la documentation officielle de **GodotAI**.
 
 Ce projet associe Godot, FastAPI et Ollama pour proposer un mini-jeu capable de communiquer avec un modèle de langage local. Toute la stack s'exécute dans des conteneurs Docker afin de rester simple à lancer.
 
-🌟 [Retrouvez le dépôt sur GitHub](https://github.com/example/GodotAI) pour explorer le code source.
+🌟 [Retrouvez le dépôt sur GitHub](https://github.com/EZPK/GodotAI/) pour explorer le code source.
 
 Cette documentation suit le cadre [Diátaxis](https://diataxis.fr/) et se divise en quatre sections :
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GodotAI
-site_url: https://github.com/example/GodotAI
+site_url: https://github.com/EZPK/GodotAI/
 theme:
   name: material
 plugins:


### PR DESCRIPTION
## Summary
- fix GitHub repository links on the docs homepage and in mkdocs config

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6840dbe226f4832ea649b040c9410bd8