### PR TITLE
🤖 Clarify agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ L’agent doit appliquer rigoureusement les instructions suivantes. Ces directiv
     Couvre chaque nouvelle fonctionnalité avec des tests automatiques.
 
     Documente tout code et tout comportement non trivial.
+    Met en avant les informations importantes avec des warnings, tips, hints, etc.
 
     Applique un formatage uniforme (utilise black pour le Python).
 


### PR DESCRIPTION
## Summary
- mention that agent may highlight warnings, tips, hints

## Testing
- `black backend/app`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6840dc2de2ac832ea0366e0b8faeb4e9