### PR TITLE
🤖 Add links between documentation articles

### DIFF
--- a/docs/guides/adapter-prompt.md
+++ b/docs/guides/adapter-prompt.md
@@ -10,3 +10,19 @@ Le fichier `Modelfile` définit le prompt système envoyé au modèle lors de ch
    make up
    ```
    Le prompt modifié sera pris en compte lors des prochaines requêtes.
+
+## Voir aussi
+
+- [Référence du `Modelfile`](../reference/modelfile.md)
+
+## FAQ
+
+### Comment vérifier que le nouveau prompt est appliqué ?
+
+Redémarrez Ollama avec `make down` puis `make up`. Les journaux indiquent le
+modèle et le prompt chargés.
+
+### Peut‑on définir plusieurs prompts ?
+
+Non. Le fichier `Modelfile` ne contient qu'une seule section `SYSTEM`. Modifiez
+cette section pour changer de prompt.

--- a/docs/guides/changer-modele.md
+++ b/docs/guides/changer-modele.md
@@ -14,3 +14,20 @@ Ce guide explique comment utiliser un autre modèle de langage avec GodotAI.
    curl http://localhost:11434/api/tags | jq
    ```
    Vous devriez voir le modèle choisi dans la liste.
+
+## Voir aussi
+
+- [Fichier `docker-compose.yml`](../reference/docker-compose-yml.md)
+- [Détails du `Modelfile`](../reference/modelfile.md)
+
+## FAQ
+
+### Pourquoi mon modèle n'est‑il pas téléchargé ?
+
+Assurez‑vous que `OLLAMA_TEXT_MODEL` dans `docker-compose.yml` correspond bien
+au modèle souhaité puis exécutez `make down` suivi de `make up`.
+
+### Puis‑je utiliser un modèle non listé ?
+
+Oui, indiquez son nom complet dans `OLLAMA_TEXT_MODEL` tant qu'il est compatible
+avec Ollama.

--- a/docs/reference/docker-compose-yml.md
+++ b/docs/reference/docker-compose-yml.md
@@ -8,3 +8,18 @@ Ce fichier coordonne les conteneurs nécessaires au projet. Il définit trois se
 Les volumes comme `ollama_models` et `sd_outputs` conservent les modèles et les résultats entre chaque exécution. Les variables d’environnement proviennent du fichier `.env` afin de personnaliser les ports ou les noms de modèle.
 
 En règle générale, `docker-compose.yml` permet de démarrer l’ensemble avec `docker compose up` ou la commande `make up` prévue dans le projet.
+
+## Voir aussi
+
+- [Guide pour changer de modèle](../guides/changer-modele.md)
+- [Explications sur Docker Compose](../explications/docker-compose.md)
+
+## FAQ
+
+### Peut‑on modifier les ports exposés ?
+
+Oui. Mettez à jour les variables correspondantes dans `.env` puis relancez `make up`.
+
+### Comment ajouter un service supplémentaire ?
+
+Déclarez-le dans `docker-compose.yml` et complétez éventuellement le `Makefile`.

--- a/docs/reference/modelfile.md
+++ b/docs/reference/modelfile.md
@@ -15,3 +15,17 @@ Tu es un maître du jeu francophone...
 La directive `FROM` choisit la base du modèle. Les lignes `PARAMETER` ajustent son comportement, par exemple la créativité (`temperature`) ou la taille du contexte (`num_ctx`). Le bloc `SYSTEM` contient le prompt envoyé au modèle à chaque requête.
 
 Ce fichier est copié dans l'image Ollama construite via `Dockerfile.ollama`. En le modifiant, on peut changer de modèle ou personnaliser l'expérience de jeu.
+
+## Voir aussi
+
+- [Guide pour adapter le prompt](../guides/adapter-prompt.md)
+
+## FAQ
+
+### Où se trouve ce fichier dans le conteneur ?
+
+Il est intégré à l'image Ollama lors de la construction. Toute modification nécessite donc un redémarrage via `make up` pour être prise en compte.
+
+### Peut‑on utiliser plusieurs Modelfiles ?
+
+`docker-compose.yml` fait référence à un unique `Modelfile`. Pour tester plusieurs prompts, modifiez ce fichier puis redémarrez Ollama.


### PR DESCRIPTION
## Summary
- crosslink docs to reference `Modelfile` and `docker-compose.yml`
- link `Modelfile` reference back to the adapter guide
- add FAQs to updated pages

## Testing
- `black backend/app`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6840ddb9c4c0832eb1c8c56192c6f521