### PR TITLE
🤖 Add Vale lint documentation

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,3 +2,4 @@ MinAlertLevel = warning
 
 [*]
 BasedOnStyles = Vale
+Vale.Spelling = NO

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,10 @@ L’agent doit appliquer rigoureusement les instructions suivantes. Ces directiv
 
     mkdocs build
 
+    Vérifie la qualité rédactionnelle avec :
+
+    vale docs/
+
 8. Méthode Diátaxis
 
 Respecte la structure **Diátaxis** pour toute la documentation :

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,3 +6,4 @@ Ces guides répondent à des besoins précis une fois l'installation terminée.
 - ✏️ [Adapter le prompt](adapter-prompt.md) : personnaliser le prompt système.
 - 📡 [Utiliser l'API](utiliser-api.md) : interagir avec FastAPI sans passer par Godot.
 - 🩺 [Dépannage modèles et GPU](depannage-modeles-gpu.md) : résoudre les soucis de démarrage ou de ressources.
+- ✍️ [Contrôler la rédaction avec Vale](qualite-redaction-vale.md) : vérifier la cohérence des articles.

--- a/docs/guides/qualite-redaction-vale.md
+++ b/docs/guides/qualite-redaction-vale.md
@@ -1,0 +1,38 @@
+# ✍️ Contrôler la rédaction avec Vale
+
+Ce guide explique comment utiliser **Vale** pour harmoniser la documentation. Vale vérifie la grammaire, la ponctuation et applique un ton cohérent.
+
+## Installer Vale
+
+Téléchargez la dernière version depuis [GitHub](https://github.com/errata-ai/vale/releases) et placez l'exécutable dans votre `PATH`.
+
+```bash
+curl -L https://github.com/errata-ai/vale/releases/latest/download/vale_3.11.2_Linux_64-bit.tar.gz \
+  | tar -xz
+sudo mv vale /usr/local/bin/
+```
+
+## Utiliser le fichier `.vale.ini`
+
+Le dépôt fournit une configuration minimale :
+
+```ini
+MinAlertLevel = warning
+[*]
+BasedOnStyles = Vale
+```
+
+Lancez Vale sur le dossier `docs` pour vérifier tous les articles :
+
+```bash
+vale docs/
+```
+
+## Bonnes pratiques
+
+- Rédigez des phrases courtes et directes.
+- Préférez la voix active.
+- Évitez les adverbes superflus.
+- Vérifiez les liens et le format Markdown avant de lancer Vale.
+
+En suivant ces conseils, la documentation reste claire et professionnelle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ Cette documentation suit le cadre [Diátaxis](https://diataxis.fr/) et se divise
 - ✏️ [Adapter le prompt](guides/adapter-prompt.md)
 - 📡 [Utiliser l'API](guides/utiliser-api.md)
 - 🩺 [Dépannage modèles et GPU](guides/depannage-modeles-gpu.md)
+- ✍️ [Contrôler la rédaction avec Vale](guides/qualite-redaction-vale.md)
 
 ### 📚 Référence technique
 - 🔗 [API du backend](reference/api-backend.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - "Adapter le prompt": guides/adapter-prompt.md
       - "Utiliser l'API": guides/utiliser-api.md
       - "Dépannage modèles et GPU": guides/depannage-modeles-gpu.md
+      - "Contrôler la rédaction avec Vale": guides/qualite-redaction-vale.md
   - Référence technique:
       - "Présentation": reference/index.md
       - "API du backend": reference/api-backend.md


### PR DESCRIPTION
## Summary
- document Vale usage for docs authors
- link new guide in navigation and index
- disable spellcheck in `.vale.ini`
- run Vale automatically via AGENTS guidelines

## Testing
- `black backend/app`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `mkdocs build`
- `vale docs`


------
https://chatgpt.com/codex/tasks/task_e_6840de8d7f28832e8ffcd8b5fd4e9a54