### PR TITLE
🤖 Add custom Vale style

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,7 @@
 MinAlertLevel = warning
+StylesPath = .vale/styles
 
 [*]
 BasedOnStyles = Vale
+Packages = CoolStyle
 Vale.Spelling = NO

--- a/.vale/styles/CoolStyle/Emojis.yml
+++ b/.vale/styles/CoolStyle/Emojis.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Ajoute un emoji pour renforcer le ton dynamique."
+level: suggestion
+scope: sentence
+nonword: true
+tokens:
+  - "Bravo"
+  - "Félicitations"
+  - "Attention"
+  - "Note"

--- a/.vale/styles/CoolStyle/Jargon.yml
+++ b/.vale/styles/CoolStyle/Jargon.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: "Remplace '%s' par '%s' pour une meilleure compréhension."
+level: suggestion
+ignorecase: true
+swap:
+  "implémentation": "mise en place"
+  "déploiement": "installation"
+  "initialisation": "démarrage"
+  "authentification": "connexion"

--- a/.vale/styles/CoolStyle/PassiveVoice.yml
+++ b/.vale/styles/CoolStyle/PassiveVoice.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Évite la voix passive pour un ton plus engageant."
+level: warning
+scope: sentence
+nonword: true
+tokens:
+  - "est .*é"
+  - "sont .*és"
+  - "a été .*é"
+  - "ont été .*és"

--- a/.vale/styles/CoolStyle/Redundancy.yml
+++ b/.vale/styles/CoolStyle/Redundancy.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: "Simplifie '%s' en '%s'."
+level: suggestion
+ignorecase: true
+swap:
+  "au jour d'aujourd'hui": "aujourd'hui"
+  "prévoir à l'avance": "prévoir"
+  "collaborer ensemble": "collaborer"
+  "monter en haut": "monter"

--- a/.vale/styles/CoolStyle/Tone.yml
+++ b/.vale/styles/CoolStyle/Tone.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: "Préférez '%s' à '%s' pour un ton plus direct."
+level: suggestion
+ignorecase: true
+swap:
+  "il est recommandé de": "tu devrais"
+  "il est nécessaire de": "tu dois"
+  "nous allons": "on va"
+  "il convient de": "tu peux"

--- a/docs/guides/qualite-redaction-vale.md
+++ b/docs/guides/qualite-redaction-vale.md
@@ -14,12 +14,15 @@ sudo mv vale /usr/local/bin/
 
 ## Utiliser le fichier `.vale.ini`
 
-Le dépôt fournit une configuration minimale :
+Le dépôt fournit une configuration personnalisée :
 
 ```ini
 MinAlertLevel = warning
+StylesPath = .vale/styles
+
 [*]
 BasedOnStyles = Vale
+Packages = CoolStyle
 ```
 
 Lancez Vale sur le dossier `docs` pour vérifier tous les articles :

--- a/docs/reference/vale.md
+++ b/docs/reference/vale.md
@@ -1,9 +1,11 @@
 # 🔍 .vale.ini
 
-`Vale` est un outil de lint pour la rédaction. Ce fichier minimal active le style par défaut et affiche les alertes à partir du niveau *warning*. L’objectif est d’harmoniser le ton de la documentation sans surcharger les auteurs de messages.
+`Vale` est un outil de lint pour la rédaction. Le projet active un style personnalisable pour un ton plus direct et cohérent.
 
 Contenu principal :
 - `MinAlertLevel = warning` : ne signale que les règles importantes.
-- `BasedOnStyles = Vale` : utilise le jeu de règles standard fourni par l’outil.
+- `StylesPath = .vale/styles` : localisation des règles maison.
+- `BasedOnStyles = Vale` : conserve le jeu de règles standard.
+- `Packages = CoolStyle` : applique nos règles supplémentaires.
 
-Ainsi, `.vale.ini` permet de vérifier rapidement les textes sans configuration complexe.
+Ainsi, `.vale.ini` permet de vérifier rapidement les textes tout en profitant de règles adaptées au projet.


### PR DESCRIPTION
## Summary
- customize `.vale.ini` with `CoolStyle`
- document Vale setup in guides and references
- add new rules: tone, emojis, passive voice, jargon, redundancy

## Testing
- `vale docs/`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6840e4dc671c832eb4cb622705929acd