### PR TITLE
🤖 Improve doc cross-links

### DIFF
--- a/docs/explications/architecture.md
+++ b/docs/explications/architecture.md
@@ -43,3 +43,7 @@ resp = requests.post(
 )
 print(resp.json())
 ```
+
+## Voir aussi
+
+- [Tutoriel de prise en main](../tutoriels/premiers-pas.md)

--- a/docs/explications/backend.md
+++ b/docs/explications/backend.md
@@ -44,3 +44,8 @@ proviennent de ce fichier. Les valeurs peuvent être surchargées via un fichier
 En résumé, le backend combine FastAPI, SQLAlchemy et plusieurs services externes
 pour orchestrer la partie narrative du mini-jeu Godot. L'ensemble est démarré
 par Docker Compose et reste facilement extensible.
+
+## Voir aussi
+
+- [Référence de l'API](../reference/api-backend.md)
+- [Explications sur FastAPI](fastapi.md)

--- a/docs/explications/bootstrap.md
+++ b/docs/explications/bootstrap.md
@@ -40,3 +40,7 @@ avant de démarrer la WebUI.
 5. **Lancement de `fastapi`** : une fois les services précédents disponibles, Uvicorn
 exécute `backend.app.backend_server:app`.
 6. **Application prête** : Godot ou tout autre client peut désormais appeler l'API.
+
+## Voir aussi
+
+- [Tutoriel de démarrage](../tutoriels/premiers-pas.md)

--- a/docs/explications/docker-compose.md
+++ b/docs/explications/docker-compose.md
@@ -21,6 +21,11 @@ make up
 make down
 ```
 
+## Voir aussi
+
+- [Fichier `docker-compose.yml`](../reference/docker-compose-yml.md)
+- [Makefile](../reference/makefile.md)
+
 ## Ressources
 - [Site officiel](https://www.docker.com/)
 - [Documentation](https://docs.docker.com/compose/)

--- a/docs/explications/fastapi.md
+++ b/docs/explications/fastapi.md
@@ -28,6 +28,11 @@ def ping():
     return {"message": "pong"}
 ```
 
+## Voir aussi
+
+- [Référence de l'API](../reference/api-backend.md)
+- [Guide d'utilisation de l'API](../guides/utiliser-api.md)
+
 ## Ressources
 - [Site officiel](https://fastapi.tiangolo.com/)
 - [Documentation](https://fastapi.tiangolo.com/)

--- a/docs/explications/godot.md
+++ b/docs/explications/godot.md
@@ -23,6 +23,11 @@ Pour lancer l'éditeur :
 make run-godot
 ```
 
+## Voir aussi
+
+- [Utiliser l'API REST](../guides/utiliser-api.md)
+- [Architecture globale](architecture.md)
+
 ## Ressources
 - [Site officiel](https://godotengine.org/)
 - [Documentation](https://docs.godotengine.org/en/stable/)

--- a/docs/explications/mkdocs.md
+++ b/docs/explications/mkdocs.md
@@ -16,6 +16,11 @@ make install
 make docs-serve
 ```
 
+## Voir aussi
+
+- [Fichier `mkdocs.yml`](../reference/mkdocs-yml.md)
+- [Contrôler la rédaction avec Vale](../guides/qualite-redaction-vale.md)
+
 ## Ressources
 - [Site officiel](https://www.mkdocs.org/)
 - [Documentation](https://www.mkdocs.org/user-guide/)

--- a/docs/explications/ollama.md
+++ b/docs/explications/ollama.md
@@ -19,6 +19,11 @@ Le fichier `Modelfile` à la racine du dépôt indique quel modèle charger. Fas
 lui envoie les requêtes de l'utilisateur pour obtenir une réponse adaptée à la
 partie en cours.
 
+## Voir aussi
+
+- [Fichier `Modelfile`](../reference/modelfile.md)
+- [Changer de modèle](../guides/changer-modele.md)
+
 ```mermaid
 flowchart LR
     A(FastAPI) -- requête --> O(Ollama)

--- a/docs/explications/stable-diffusion.md
+++ b/docs/explications/stable-diffusion.md
@@ -24,6 +24,11 @@ curl -X POST http://localhost:8000/generate-image \
   -d '{"prompt": "un village médiéval"}' -o output.png
 ```
 
+## Voir aussi
+
+- [Configuration des services](../reference/docker-compose-yml.md)
+- [Guide d'utilisation de l'API](../guides/utiliser-api.md)
+
 ## Ressources
 - [Site officiel](https://stability.ai/)
 - [Documentation](https://github.com/Stability-AI/stablediffusion)

--- a/docs/guides/adapter-prompt.md
+++ b/docs/guides/adapter-prompt.md
@@ -14,6 +14,7 @@ Le fichier `Modelfile` définit le prompt système envoyé au modèle lors de ch
 ## Voir aussi
 
 - [Référence du `Modelfile`](../reference/modelfile.md)
+- [Changer de modèle LLM](changer-modele.md)
 
 ## FAQ
 

--- a/docs/guides/changer-modele.md
+++ b/docs/guides/changer-modele.md
@@ -19,6 +19,7 @@ Ce guide explique comment utiliser un autre modèle de langage avec GodotAI.
 
 - [Fichier `docker-compose.yml`](../reference/docker-compose-yml.md)
 - [Détails du `Modelfile`](../reference/modelfile.md)
+- [Dépannage modèles et GPU](depannage-modeles-gpu.md)
 
 ## FAQ
 

--- a/docs/guides/depannage-modeles-gpu.md
+++ b/docs/guides/depannage-modeles-gpu.md
@@ -15,3 +15,8 @@ Quelques pistes si les modèles ne se chargent pas ou si le GPU n'est pas utilis
   ```bash
   docker exec -it ollama nvidia-smi
   ```
+
+## Voir aussi
+
+- [Changer le modèle LLM](changer-modele.md)
+- [Détails de `docker-compose.yml`](../reference/docker-compose-yml.md)

--- a/docs/guides/qualite-redaction-vale.md
+++ b/docs/guides/qualite-redaction-vale.md
@@ -28,6 +28,10 @@ Lancez Vale sur le dossier `docs` pour vérifier tous les articles :
 vale docs/
 ```
 
+## Voir aussi
+
+- [Fichier `.vale.ini` détaillé](../reference/vale.md)
+
 ## Bonnes pratiques
 
 - Rédigez des phrases courtes et directes.

--- a/docs/guides/utiliser-api.md
+++ b/docs/guides/utiliser-api.md
@@ -9,3 +9,8 @@ curl -X POST http://localhost:8000/gen_text \
      -d '{"context": "Bonjour"}'
 ```
 La réponse est un objet JSON contenant le texte généré.
+
+## Voir aussi
+
+- [Endpoints détaillés](../reference/api-backend.md)
+- [Explications sur FastAPI](../explications/fastapi.md)

--- a/docs/reference/agents-file.md
+++ b/docs/reference/agents-file.md
@@ -8,3 +8,7 @@
 
 Ces règles assurent une base de code cohérente et des contributions faciles à relire.
 
+## Voir aussi
+
+- [Tests unitaires](tests-unitaires.md)
+

--- a/docs/reference/api-backend.md
+++ b/docs/reference/api-backend.md
@@ -19,3 +19,7 @@ Pour lancer l'API seule en local :
 ```bash
 make run-api
 ```
+
+## Voir aussi
+
+- [Guide d'utilisation de l'API](../guides/utiliser-api.md)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -10,9 +10,13 @@ Principales variables d'environnement :
 
 Fichiers importants :
 
-- `docker-compose.yml` orchestre les services.
-- `Modelfile` décrit le modèle et le prompt système.
-- `Dockerfile.ollama` construit l'image Ollama personnalisée.
+- [`docker-compose.yml`](docker-compose-yml.md) orchestre les services.
+- [`Modelfile`](modelfile.md) décrit le modèle et le prompt système.
+- [`Dockerfile.ollama`](dockerfile-ollama.md) construit l'image Ollama personnalisée.
 
 
 Après toute modification, redémarrez la stack via `make down` puis `make up` pour appliquer les nouvelles valeurs.
+
+## Voir aussi
+
+- [Changer le modèle LLM](../guides/changer-modele.md)

--- a/docs/reference/dockerfile-ollama.md
+++ b/docs/reference/dockerfile-ollama.md
@@ -17,3 +17,8 @@ L’entrée `ENTRYPOINT` lance ce script pour s’assurer que les modèles préc
 Ce conteneur se combine ensuite avec le service FastAPI via `docker compose up`.
 
 Lancez la stack et la construction de l'image avec `make up`.
+
+## Voir aussi
+
+- [Script `entrypoint_ollama.sh`](entrypoint-ollama.md)
+- [Fichier `Modelfile`](modelfile.md)

--- a/docs/reference/dockerfile.md
+++ b/docs/reference/dockerfile.md
@@ -11,3 +11,7 @@ CMD ["uvicorn", "backend.app.backend_server:app", "--host", "0.0.0.0", "--port",
 Ce service est ensuite démarré par `docker-compose.yml` sous le nom **fastapi**.
 
 Rebâtissez cette image et relancez FastAPI avec `make rebuild`.
+
+## Voir aussi
+
+- [`docker-compose.yml`](docker-compose-yml.md)

--- a/docs/reference/entrypoint-ollama.md
+++ b/docs/reference/entrypoint-ollama.md
@@ -11,3 +11,8 @@ Ce script s'exécute lorsque le conteneur Ollama démarre. Son rôle est de pré
 Grâce à cette séquence, on dispose d'un service prêt à répondre dès le premier `docker compose up`.
 
 Ce processus complet se déclenche automatiquement lors d'un `make up`.
+
+## Voir aussi
+
+- [Dockerfile.ollama](dockerfile-ollama.md)
+- [Modelfile](modelfile.md)

--- a/docs/reference/gitignore.md
+++ b/docs/reference/gitignore.md
@@ -8,3 +8,7 @@ Principales entrées :
 - Le dossier `ollama_models` et autres volumes Docker ne sont pas suivis pour préserver l’espace du répertoire Git.
 
 En résumé, `.gitignore` garde le dépôt propre et léger.
+
+## Voir aussi
+
+- [Configuration des volumes](docker-compose-yml.md)

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -12,3 +12,8 @@ Le `Makefile` centralise plusieurs commandes utiles :
 - `make universe` exécute tous les tests et génère `rapports/universe.log`.
 
 En résumé, il simplifie le quotidien en évitant de longues lignes de commande.
+
+## Voir aussi
+
+- [Fichier `docker-compose.yml`](docker-compose-yml.md)
+- [Tests unitaires](tests-unitaires.md)

--- a/docs/reference/mkdocs-yml.md
+++ b/docs/reference/mkdocs-yml.md
@@ -18,3 +18,7 @@ mkdocs build
 Cette commande s'assure que la documentation est valide avant une éventuelle publication.
 
 Pour faciliter ces actions, utilisez `make docs-serve` pour un aperçu local et `make docs-deploy` pour la publication.
+
+## Voir aussi
+
+- [Présentation de MkDocs](../explications/mkdocs.md)

--- a/docs/reference/test-services.md
+++ b/docs/reference/test-services.md
@@ -13,3 +13,7 @@
    ```
 
 Ce test est à exécuter juste après `make up` pour vous assurer que la stack est opérationnelle. Il affiche pour chaque service s'il est joignable. Un emoji indique l'état : `✅` si tout fonctionne, `⏳` lorsque Stable Diffusion charge encore son modèle et `❌` en cas d'erreur. Le script renvoie un code de sortie non nul si un service est indisponible.
+
+## Voir aussi
+
+- [Tutoriel de prise en main](../tutoriels/premiers-pas.md)

--- a/docs/reference/tests-e2e.md
+++ b/docs/reference/tests-e2e.md
@@ -18,3 +18,8 @@ pytest e2e
 
 Le script démarre brièvement le serveur FastAPI sur un port local puis effectue
 un appel HTTP via l'API `request` de Playwright.
+
+## Voir aussi
+
+- [Tests unitaires](tests-unitaires.md)
+- [Guide de démarrage](../tutoriels/premiers-pas.md)

--- a/docs/reference/tests-unitaires.md
+++ b/docs/reference/tests-unitaires.md
@@ -18,3 +18,8 @@ make install
 
 Chaque nouvelle fonctionnalité Python doit être accompagnée d'un test
 correspondant dans ce répertoire.
+
+## Voir aussi
+
+- [Tests E2E](tests-e2e.md)
+- [AGENTS.md](agents-file.md)

--- a/docs/reference/vale.md
+++ b/docs/reference/vale.md
@@ -7,3 +7,7 @@ Contenu principal :
 - `BasedOnStyles = Vale` : utilise le jeu de règles standard fourni par l’outil.
 
 Ainsi, `.vale.ini` permet de vérifier rapidement les textes sans configuration complexe.
+
+## Voir aussi
+
+- [Guide d'utilisation de Vale](../guides/qualite-redaction-vale.md)

--- a/docs/tutoriels/premiers-pas.md
+++ b/docs/tutoriels/premiers-pas.md
@@ -29,6 +29,7 @@ Suivez les étapes ci-dessous dans l'ordre pour déployer la stack complète.
    .venv/bin/python utils/test_services.py
    ```
    Ce script s'assure que chaque service est joignable.
+   Pour plus de détails, consultez [test_services.py](../reference/test-services.md).
 5. (Optionnel) Lancez Godot :
    ```bash
    make run-godot
@@ -46,3 +47,4 @@ Suivez les étapes ci-dessous dans l'ordre pour déployer la stack complète.
 Tous les outils mentionnés disposent de liens vers leur site officiel et leur documentation sur les pages correspondantes.
 
 Une fois ces étapes terminées, vous pouvez explorer les guides pratiques pour personnaliser le projet.
+[Accéder aux guides](../guides/index.md)


### PR DESCRIPTION
## Summary
- add internal links across the docs
- run mkdocs build and linkchecker
- run Vale on documentation

## Testing
- `python -m mkdocs build`
- `linkchecker site/index.html --no-status`
- `vale docs/`


------
https://chatgpt.com/codex/tasks/task_e_6840e5d2212c832e9fe3cda5cb3445e2