### PR TITLE
🤖 Improve Mermaid diagrams

### DIFF
--- a/docs/explications/architecture.md
+++ b/docs/explications/architecture.md
@@ -5,6 +5,7 @@ Cette page présente brièvement l'architecture générale avant de détailler c
 Le diagramme ci-dessous est généré avec **Mermaid** :
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart TD
     U[Utilisateur]
     U --> G[Godot 🎮]

--- a/docs/explications/docker-compose.md
+++ b/docs/explications/docker-compose.md
@@ -4,6 +4,7 @@ Docker Compose est l'outil qui lance plusieurs conteneurs Docker en une seule co
 Le fichier `docker-compose.yml` définit trois services : **fastapi**, **ollama** et **stablediffusion**.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     DC[Docker Compose] --> F(fastapi)
     DC --> O(ollama)

--- a/docs/explications/fastapi.md
+++ b/docs/explications/fastapi.md
@@ -10,6 +10,7 @@ déclenche la génération d'images via Stable Diffusion. Il stocke aussi les
 informations de partie dans SQLite.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     G[Godot] --> F(FastAPI)
     F --> O[Ollama]

--- a/docs/explications/godot.md
+++ b/docs/explications/godot.md
@@ -8,6 +8,7 @@ Quand le joueur effectue une action, ces scripts envoient la requête à FastAPI
 qui renvoie le texte généré par Ollama.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 sequenceDiagram
     participant P as Joueur
     participant G as Godot

--- a/docs/explications/mkdocs.md
+++ b/docs/explications/mkdocs.md
@@ -5,6 +5,7 @@ MkDocs transforme les fichiers Markdown du dossier `docs/` en un site statique p
 La configuration active également le plugin [Mermaid](https://github.com/fralau/mkdocs-mermaid2-plugin) pour intégrer des schémas.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     M[Markdown] --> MK(MkDocs)
     MK --> HTML[Site statique]

--- a/docs/explications/ollama.md
+++ b/docs/explications/ollama.md
@@ -25,6 +25,7 @@ partie en cours.
 - [Changer de modèle](../guides/changer-modele.md)
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     A(FastAPI) -- requête --> O(Ollama)
     O -- réponse --> A

--- a/docs/explications/stable-diffusion.md
+++ b/docs/explications/stable-diffusion.md
@@ -12,6 +12,7 @@ téléchargés avant que l'interface WebUI ne se lance.
 FastAPI lui transmet vos invites afin d'illustrer certaines scènes du jeu.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     A(FastAPI) -- prompt --> SD[Stable Diffusion]
     SD -- image --> A


### PR DESCRIPTION
## Summary
- use Material-style theme in all Mermaid diagrams

## Testing
- `mkdocs build`
- `vale docs/`

------
https://chatgpt.com/codex/tasks/task_e_6840ea2d9ecc832eb9f9a922c2f1d4a8