### PR TITLE
🤖 Enhance documentation with examples and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 GodotAI combine Godot, FastAPI et Ollama pour expérimenter localement l'intelligence artificielle dans un mini-jeu. Tout fonctionne dans des conteneurs Docker pour une mise en route rapide.
 
 👉 Consultez la [documentation complète](https://ezpk.github.io/GodotAI/) pour suivre le tutoriel de prise en main et découvrir les guides, la référence et les explications détaillées.
+
+## Architecture rapide
+
+```mermaid
+flowchart LR
+    G[Godot] -->|HTTP| A[FastAPI]
+    A --> O[Ollama]
+    A --> SD[Stable Diffusion]
+    A --> DB[(SQLite)]
+```
+
+Godot envoie les actions du joueur à FastAPI qui interroge Ollama pour le texte et
+Stable Diffusion pour les images. Les données sont stockées dans SQLite.

--- a/docs/explications/godot.md
+++ b/docs/explications/godot.md
@@ -18,6 +18,22 @@ sequenceDiagram
     G-->>P: affichage
 ```
 
+Extrait de la fonction d'envoi d'un message au modèle :
+
+```gdscript
+func _send_to_llm(message: String):
+    var url := "http://localhost:11434/api/generate"
+    var body := {
+        "model": "god:latest",
+        "prompt": message,
+        "stream": true
+    }
+    var headers := ["Content-Type: application/json"]
+    var err := http.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(body))
+    if err != OK:
+        _append_message("Assistant", "[Erreur r\u00e9seau]")
+```
+
 Pour lancer l'éditeur :
 ```bash
 make run-godot

--- a/docs/reference/tests-e2e.md
+++ b/docs/reference/tests-e2e.md
@@ -19,6 +19,18 @@ pytest e2e
 Le script démarre brièvement le serveur FastAPI sur un port local puis effectue
 un appel HTTP via l'API `request` de Playwright.
 
+Extrait du fichier `test_api_playwright.py` :
+
+```python
+from playwright.sync_api import sync_playwright
+
+def test_root_endpoint():
+    with sync_playwright() as p:
+        request = p.request.new_context(base_url="http://127.0.0.1:8002")
+        resp = request.get("/")
+        assert resp.status == 200
+```
+
 ## Voir aussi
 
 - [Tests unitaires](tests-unitaires.md)

--- a/docs/reference/tests-unitaires.md
+++ b/docs/reference/tests-unitaires.md
@@ -9,6 +9,26 @@ Pour exécuter l'ensemble des tests :
 pytest -q
 ```
 
+Exemple de test issu du fichier `test_root.py` :
+
+```python
+from fastapi.testclient import TestClient
+from backend.app.backend_server import app
+
+client = TestClient(app)
+
+def test_read_root():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Backend FastAPI fonctionne !"
+```
+
+Pour cibler un seul test pendant le développement :
+
+```bash
+pytest backend/tests/test_root.py::test_read_root -q
+```
+
 Les dépendances nécessaires sont listées dans `backend/requirements.txt`.
 Avant de lancer les tests pour la première fois, installez-les avec :
 

--- a/docs/tutoriels/premiers-pas.md
+++ b/docs/tutoriels/premiers-pas.md
@@ -2,13 +2,27 @@
 
 Suivez les étapes ci-dessous dans l'ordre pour déployer la stack complète.
 
-1. Installez [Docker](https://docs.docker.com/get-docker/) et [Git](https://git-scm.com/).
-2. Clonez le dépôt :
+1. Préparez les variables d'environnement en copiant le fichier `.env` fourni puis ajustez les valeurs selon vos besoins :
+   ```bash
+   cp .env .env.local
+   # OLLAMA_TEXT_MODEL=god:latest
+   # OLLAMA_IMAGE_MODEL=stable-diffusion
+   ```
+   Consultez la [référence](../reference/configuration.md) pour la liste complète des variables.
+
+2. Installez [Docker](https://docs.docker.com/get-docker/) et [Git](https://git-scm.com/).
+3. Clonez le dépôt :
    ```bash
    git clone <repo_url>
    cd godot_ai
    ```
-3. Démarrez les services :
+4. Installez les dépendances Python puis vérifiez la configuration :
+   ```bash
+   make install
+   .venv/bin/python utils/test_services.py
+   ```
+   Ce script confirme que chaque service est joignable.
+5. Démarrez les services :
    ```bash
    make up
    ```
@@ -23,23 +37,17 @@ Suivez les étapes ci-dessous dans l'ordre pour déployer la stack complète.
    Le script `entrypoint_ollama.sh` lance `ollama serve` puis vérifie la
    présence des modèles. S'ils sont absents, il exécute `ollama pull` pour les
    récupérer avant de poursuivre l'initialisation.
-4. Installez les dépendances Python puis vérifiez que FastAPI, Ollama et Stable Diffusion répondent :
-   ```bash
-   make install
-   .venv/bin/python utils/test_services.py
-   ```
-   Ce script s'assure que chaque service est joignable.
    Pour plus de détails, consultez [test_services.py](../reference/test-services.md).
-5. (Optionnel) Lancez Godot :
+6. (Optionnel) Lancez Godot :
    ```bash
    make run-godot
    ```
-6. (Optionnel) Exécutez les tests unitaires et E2E :
+7. (Optionnel) Exécutez les tests unitaires et E2E :
    ```bash
    pytest -q
    pytest e2e
    ```
-7. Coupez les conteneurs :
+8. Coupez les conteneurs :
    ```bash
    make down
    ```


### PR DESCRIPTION
## Summary
- detail environment setup in the quickstart
- show high level architecture in README
- add GDScript integration snippet
- expand unit and e2e testing docs

## Testing
- `black backend/app`
- `.venv/bin/mkdocs build`
- `vale docs/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ea696d80832e8fa4ed3e1bb41783