### PR TITLE
🤖 Improve env variable docs

### DIFF
--- a/docs/guides/configurer-env.md
+++ b/docs/guides/configurer-env.md
@@ -1,0 +1,17 @@
+# ⚙️ Configurer l'environnement
+
+Ce guide explique comment personnaliser les variables d'environnement de GodotAI.
+
+1. Ouvrez le fichier `.env` à la racine du dépôt.
+2. Modifiez les valeurs selon vos besoins : modèles, ports ou chemin de Godot.
+3. Redémarrez la stack pour appliquer les changements :
+   ```bash
+   make down
+   make up
+   ```
+
+Pour utiliser le GPU, définissez `NVIDIA_VISIBLE_DEVICES=all` avant de lancer `make up`.
+
+## Voir aussi
+
+- [Liste des variables](../reference/variables-env.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,6 +5,7 @@ Ces guides répondent à des besoins précis une fois l'installation terminée.
 - 🔄 [Changer le modèle LLM](changer-modele.md) : télécharger et utiliser une autre base.
 - ✏️ [Adapter le prompt](adapter-prompt.md) : personnaliser le prompt système.
 - 📡 [Utiliser l'API](utiliser-api.md) : interagir avec FastAPI sans passer par Godot.
+- ⚙️ [Configurer l'environnement](configurer-env.md) : définir les variables dans `.env`.
 - 🩺 [Dépannage modèles et GPU](depannage-modeles-gpu.md) : résoudre les soucis de démarrage ou de ressources.
 - ✍️ [Contrôler la rédaction avec Vale](qualite-redaction-vale.md) : vérifier la cohérence des articles.
 - 🛠️ [Troubleshooting](troubleshooting.md) : résoudre les erreurs courantes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ Cette documentation suit le cadre [Diátaxis](https://diataxis.fr/) et se divise
 - 🔄 [Changer le modèle LLM](guides/changer-modele.md)
 - ✏️ [Adapter le prompt](guides/adapter-prompt.md)
 - 📡 [Utiliser l'API](guides/utiliser-api.md)
+- ⚙️ [Configurer l'environnement](guides/configurer-env.md)
 - 🩺 [Dépannage modèles et GPU](guides/depannage-modeles-gpu.md)
 - ✍️ [Contrôler la rédaction avec Vale](guides/qualite-redaction-vale.md)
 - 🛠️ [Troubleshooting](guides/troubleshooting.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,6 +10,7 @@ Cette section recense les fichiers essentiels du dépôt et la façon de les uti
 - [`Modelfile`](modelfile.md) : définit le prompt système et les paramètres du modèle.
 - [`Makefile`](makefile.md) : rassemble les commandes (`make up`, `make down`, `make docs-serve`...).
 - [`mkdocs.yml`](mkdocs-yml.md) : configure la documentation.
+- [`variables-env.md`](variables-env.md) : liste complète des variables d'environnement.
 - [`AGENTS.md`](agents-file.md) : décrit les conventions de contribution automatiques.
 
 ## Tests

--- a/docs/reference/variables-env.md
+++ b/docs/reference/variables-env.md
@@ -1,0 +1,21 @@
+# 🌡️ Variables d'environnement
+
+Le fichier `.env` centralise la configuration de l'ensemble des services. Voici la liste des variables disponibles :
+
+| Variable | Valeur par défaut | Rôle |
+|----------|--------------------|-------|
+| `OLLAMA_TEXT_MODEL` | `god:latest` | Modèle de génération de texte. |
+| `OLLAMA_TEXT_HOST` | `ollama` | Hôte du service Ollama pour le texte. |
+| `OLLAMA_TEXT_PORT` | `11434` | Port d'Ollama pour les requêtes texte. |
+| `OLLAMA_IMAGE_MODEL` | `stable-diffusion` | Modèle de génération d'images. |
+| `OLLAMA_IMAGE_HOST` | `stablediffusion` | Hôte pour la génération d'images. |
+| `OLLAMA_IMAGE_PORT` | `7860` | Port du service d'images. |
+| `GODOT_PATH` | `./Godot_v4.x86_64` | Exécutable Godot utilisé par le `Makefile`. |
+| `DATABASE_URL` | `sqlite:///./data/game.db` | Chemin de la base de données. |
+| `NVIDIA_VISIBLE_DEVICES` | _(vide)_ | Active l'accélération GPU dans les conteneurs. |
+
+Ces valeurs sont chargées automatiquement par Docker Compose et le `Makefile`.
+
+## Voir aussi
+
+- [Configurer l'environnement](../guides/configurer-env.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - "Changer le modèle LLM": guides/changer-modele.md
       - "Adapter le prompt": guides/adapter-prompt.md
       - "Utiliser l'API": guides/utiliser-api.md
+      - "Configurer l'environnement": guides/configurer-env.md
       - "Dépannage modèles et GPU": guides/depannage-modeles-gpu.md
       - "Contrôler la rédaction avec Vale": guides/qualite-redaction-vale.md
       - "Troubleshooting": guides/troubleshooting.md
@@ -31,6 +32,7 @@ nav:
       - "Modelfile": reference/modelfile.md
       - "entrypoint_ollama.sh": reference/entrypoint-ollama.md
       - "mkdocs.yml": reference/mkdocs-yml.md
+      - "Variables d'environnement": reference/variables-env.md
       - "Tests unitaires": reference/tests-unitaires.md
       - "Tests E2E": reference/tests-e2e.md
       - "Vérification des services": reference/test-services.md


### PR DESCRIPTION
## Summary
- document how to configure environment variables
- list available variables in a new reference page
- link the new pages from the docs index and mkdocs navigation

## Testing
- `vale docs/`
- `mkdocs build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6840eaba37d8832ebf84e3ea77740b84