### PR TITLE
🤖 Enable Mermaid diagrams on build

### DIFF
--- a/docs/explications/mkdocs.md
+++ b/docs/explications/mkdocs.md
@@ -2,7 +2,7 @@
 
 MkDocs transforme les fichiers Markdown du dossier `docs/` en un site statique prêt à être publié. Le thème Material apporte un rendu moderne et agréable.
 
-La configuration active également le plugin [Mermaid](https://github.com/fralau/mkdocs-mermaid2-plugin) pour intégrer des schémas.
+La configuration active également le plugin [Mermaid](https://github.com/fralau/mkdocs-mermaid2-plugin) pour intégrer des schémas. Celui‑ci insère automatiquement la bibliothèque Mermaid et initialise les diagrammes avec `securityLevel: loose`.
 
 ```mermaid
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%

--- a/docs/js/mermaid-init.js
+++ b/docs/js/mermaid-init.js
@@ -1,4 +1,0 @@
-mermaid.initialize({
-  startOnLoad: true,
-  securityLevel: 'loose'
-});

--- a/docs/reference/mkdocs-yml.md
+++ b/docs/reference/mkdocs-yml.md
@@ -7,7 +7,8 @@ Principales sections :
 - `site_name` et `site_url` définissent le nom du projet et son adresse en ligne.
 - `theme` indique le thème Material utilisé pour le rendu.
 - `nav` liste l'ensemble des pages et leur organisation dans la barre de navigation.
-- `plugins` active notamment `mermaid2` pour les diagrammes.
+- `plugins` active notamment `mermaid2` pour les diagrammes avec
+  l'option `securityLevel: loose`.
 
 Après chaque ajout de page, exécutez :
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,11 +4,12 @@ theme:
   name: material
 plugins:
   - search
-  - mermaid2
+  - mermaid2:
+      arguments:
+        startOnLoad: true
+        securityLevel: loose
 markdown_extensions:
   - pymdownx.superfences
-extra_javascript:
-  - js/mermaid-init.js
 nav:
   - Accueil: index.md
   - Tutoriels:


### PR DESCRIPTION
## Summary
- configure `mermaid2` plugin with security level `loose`
- remove custom Mermaid JS loader
- document the Mermaid plugin usage

## Testing
- `black backend/app`
- `pytest -q`
- `mkdocs build`
- `vale docs/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef2c35f0832eb42495c66f909230