### PR TITLE
🤖 Add Mermaid setup

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,6 +15,8 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: pip install mkdocs mkdocs-material mkdocs-mermaid2-plugin
+      - name: Build docs
+        run: mkdocs build
       - name: Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/mermaid-config.js
+++ b/docs/mermaid-config.js
@@ -1,0 +1,1 @@
+mermaid.initialize({ securityLevel: 'loose' });

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ plugins:
         securityLevel: loose
 markdown_extensions:
   - pymdownx.superfences
+extra_javascript:
+  - mermaid-config.js
 nav:
   - Accueil: index.md
   - Tutoriels:


### PR DESCRIPTION
## Summary
- configure MkDocs with extra_javascript for Mermaid
- add loose security config for Mermaid
- build docs in the CI workflow

## Testing
- `black backend/app`
- `pytest -q`
- `mkdocs build`
- `vale docs/`

------
https://chatgpt.com/codex/tasks/task_e_6840f155b404832e8e97514d1077f425