### PR TITLE
🤖 Fix Mermaid diagrams

### DIFF
--- a/docs/explications/architecture.md
+++ b/docs/explications/architecture.md
@@ -4,7 +4,13 @@ Cette page présente brièvement l'architecture générale avant de détailler c
 
 Le diagramme ci-dessous est généré avec **Mermaid** :
 
-```mermaid
+```html
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+<div class="mermaid">
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart TD
     U[Utilisateur]
@@ -17,6 +23,7 @@ flowchart TD
     click A "fastapi.md" "Voir la page FastAPI"
     click O "ollama.md" "Voir la page Ollama"
     click SD "stable-diffusion.md" "Voir la page Stable Diffusion"
+</div>
 ```
 
 ## Rôle des composants

--- a/docs/explications/docker-compose.md
+++ b/docs/explications/docker-compose.md
@@ -3,7 +3,13 @@
 Docker Compose est l'outil qui lance plusieurs conteneurs Docker en une seule commande.
 Le fichier `docker-compose.yml` définit trois services : **fastapi**, **ollama** et **stablediffusion**.
 
-```mermaid
+```html
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+<div class="mermaid">
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     DC[Docker Compose] --> F(fastapi)
@@ -13,6 +19,7 @@ flowchart LR
     click F "fastapi.md" "Voir la page FastAPI"
     click O "ollama.md" "Voir la page Ollama"
     click SD "stable-diffusion.md" "Voir la page Stable Diffusion"
+</div>
 ```
 
 Pour simplifier la vie du développeur, toutes les commandes utiles sont regroupées dans le `Makefile`.

--- a/docs/explications/fastapi.md
+++ b/docs/explications/fastapi.md
@@ -9,7 +9,13 @@ routes appelées par Godot, dialogue avec Ollama pour produire du texte et
 déclenche la génération d'images via Stable Diffusion. Il stocke aussi les
 informations de partie dans SQLite.
 
-```mermaid
+```html
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+<div class="mermaid">
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     G[Godot] --> F(FastAPI)
@@ -20,6 +26,7 @@ flowchart LR
     click F "fastapi.md" "Voir la page FastAPI"
     click O "ollama.md" "Voir la page Ollama"
     click SD "stable-diffusion.md" "Voir la page Stable Diffusion"
+</div>
 ```
 
 ## Exemple minimal

--- a/docs/explications/godot.md
+++ b/docs/explications/godot.md
@@ -7,7 +7,13 @@ Les scripts GDScript appellent l'endpoint `/generate-text` pour afficher les ré
 Quand le joueur effectue une action, ces scripts envoient la requête à FastAPI
 qui renvoie le texte généré par Ollama.
 
-```mermaid
+```html
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+<div class="mermaid">
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 sequenceDiagram
     participant P as Joueur
@@ -19,6 +25,7 @@ sequenceDiagram
     G-->>P: affichage
     click G "godot.md" "Voir la page Godot"
     click A "fastapi.md" "Voir la page FastAPI"
+</div>
 ```
 
 Extrait de la fonction d'envoi d'un message au modèle :

--- a/docs/explications/mkdocs.md
+++ b/docs/explications/mkdocs.md
@@ -4,12 +4,19 @@ MkDocs transforme les fichiers Markdown du dossier `docs/` en un site statique p
 
 La configuration active également le plugin [Mermaid](https://github.com/fralau/mkdocs-mermaid2-plugin) pour intégrer des schémas. Celui‑ci insère automatiquement la bibliothèque Mermaid et initialise les diagrammes avec `securityLevel: loose`.
 
-```mermaid
+```html
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+<div class="mermaid">
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     M[Markdown] --> MK(MkDocs)
     MK --> HTML[Site statique]
     click MK "mkdocs.md" "Voir la page MkDocs"
+</div>
 ```
 
 Pour tester en local :

--- a/docs/explications/ollama.md
+++ b/docs/explications/ollama.md
@@ -24,13 +24,20 @@ partie en cours.
 - [Fichier `Modelfile`](../reference/modelfile.md)
 - [Changer de modèle](../guides/changer-modele.md)
 
-```mermaid
+```html
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+<div class="mermaid">
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     A(FastAPI) -- requête --> O(Ollama)
     O -- réponse --> A
     click A "fastapi.md" "Voir la page FastAPI"
     click O "ollama.md" "Voir la page Ollama"
+</div>
 ```
 
 Exemple d'exécution manuelle :

--- a/docs/explications/stable-diffusion.md
+++ b/docs/explications/stable-diffusion.md
@@ -11,13 +11,20 @@ téléchargés avant que l'interface WebUI ne se lance.
 
 FastAPI lui transmet vos invites afin d'illustrer certaines scènes du jeu.
 
-```mermaid
+```html
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
+
+<div class="mermaid">
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%
 flowchart LR
     A(FastAPI) -- prompt --> SD[Stable Diffusion]
     SD -- image --> A
     click A "fastapi.md" "Voir la page FastAPI"
     click SD "stable-diffusion.md" "Voir la page Stable Diffusion"
+</div>
 ```
 
 Vous pouvez générer une image directement via l'API :


### PR DESCRIPTION
## Summary
- add JS snippet to render Mermaid diagrams on documentation pages

## Testing
- `black backend/app`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `mkdocs build` *(fails: command not found)*
- `vale docs/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f479dd58832e89547aaee8d1a0c3