### PR TITLE
🤖 Use Material's native Mermaid integration

### DIFF
--- a/docs/explications/mkdocs.md
+++ b/docs/explications/mkdocs.md
@@ -2,7 +2,7 @@
 
 MkDocs transforme les fichiers Markdown du dossier `docs/` en un site statique prêt à être publié. Le thème Material apporte un rendu moderne et agréable.
 
-La configuration active également le plugin [Mermaid](https://github.com/fralau/mkdocs-mermaid2-plugin) pour intégrer des schémas. Celui‑ci insère automatiquement la bibliothèque Mermaid et initialise les diagrammes avec `securityLevel: loose`.
+Depuis la version 8 du thème, Mermaid est pris en charge nativement. En déclarant simplement un bloc de code `mermaid`, le script est chargé et les diagrammes sont rendus automatiquement.
 
 ```mermaid
 %%{init: {'theme':'base','themeVariables':{'primaryColor':'#6200ee','primaryTextColor':'#ffffff','primaryBorderColor':'#6200ee','lineColor':'#6200ee','fontFamily':'Roboto'}}}%%

--- a/docs/reference/mkdocs-yml.md
+++ b/docs/reference/mkdocs-yml.md
@@ -7,8 +7,8 @@ Principales sections :
 - `site_name` et `site_url` définissent le nom du projet et son adresse en ligne.
 - `theme` indique le thème Material utilisé pour le rendu.
 - `nav` liste l'ensemble des pages et leur organisation dans la barre de navigation.
-- `plugins` active notamment `mermaid2` pour les diagrammes avec
-  l'option `securityLevel: loose`.
+- `markdown_extensions` configure un fence `mermaid` via **SuperFences**.
+  Material charge alors automatiquement la bibliothèque Mermaid.
 
 Après chaque ajout de page, exécutez :
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,12 +4,12 @@ theme:
   name: material
 plugins:
   - search
-  - mermaid2:
-      arguments:
-        startOnLoad: true
-        securityLevel: loose
 markdown_extensions:
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 extra_javascript:
   - mermaid-config.js
 nav:


### PR DESCRIPTION
## Summary
- remove mkdocs-mermaid2 plugin
- configure Mermaid fence using SuperFences
- document the change in the MkDocs explanation and reference pages

## Testing
- `mkdocs build`
- `vale docs/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840faff9380832e89825ae891411a48