### PR TITLE
🤖 Add Mermaid2 support

### DIFF
--- a/docs/reference/mkdocs-yml.md
+++ b/docs/reference/mkdocs-yml.md
@@ -6,6 +6,7 @@ Principales sections :
 
 - `site_name` et `site_url` définissent le nom du projet et son adresse en ligne.
 - `theme` indique le thème Material utilisé pour le rendu.
+- `plugins` active `mermaid2` pour gérer les diagrammes.
 - `nav` liste l'ensemble des pages et leur organisation dans la barre de navigation.
 - `markdown_extensions` configure un fence `mermaid` via **SuperFences**.
   Material charge alors automatiquement la bibliothèque Mermaid.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ theme:
   name: material
 plugins:
   - search
+  - mermaid2
 markdown_extensions:
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
## Summary
- enable mermaid2 plugin in mkdocs
- document plugin usage in reference docs

## Testing
- `black backend/app`
- `pytest -q`
- `mkdocs build`
- `vale docs/`

------
https://chatgpt.com/codex/tasks/task_e_68410029337c832eaa38dbef96ac5efd