### PR TITLE
🤖 Add homepage architecture diagram

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,15 @@ Ce projet associe Godot, FastAPI et Ollama pour proposer un mini-jeu capable de 
 
 🌟 [Retrouvez le dépôt sur GitHub](https://github.com/EZPK/GodotAI/) pour explorer le code source.
 
+## Aperçu de l'architecture
+
+Voici le fonctionnement général : le joueur dialogue avec **Godot**, qui fait
+appel au backend **FastAPI**. Celui-ci interroge **Ollama** pour le texte et
+**Stable Diffusion** pour l'image, puis consigne les échanges dans **SQLite**
+avant de répondre au client.
+
+![Architecture](assets/architecture.svg)
+
 Cette documentation suit le cadre [Diátaxis](https://diataxis.fr/) et se divise en quatre sections :
 
 - **Tutoriels** 🛠️ : apprenez pas à pas à installer et utiliser le projet.


### PR DESCRIPTION
## Summary
- show the global architecture in the homepage
- explain the request/response flow

## Testing
- `pytest -q`
- `mkdocs build`
- `vale docs/` *(fails: Vale.Repetition in diagrams)*

------
https://chatgpt.com/codex/tasks/task_e_68410c285890832e8e26629375b99554