### PR TITLE
🤖 Load env vars in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@
 
 .DEFAULT_GOAL := help
 
-ifneq (,$(wildcard ./.env))
-	include .env
-	export
+ifneq (,$(wildcard .env))
+include .env
+export
 endif
 
-GODOT_PATH ?= godot4
+ifndef GODOT_PATH
+GODOT_PATH := $(shell command -v godot4 2>/dev/null || echo godot4)
+endif
 VENV_DIR ?= .venv
 PYTHON := $(VENV_DIR)/bin/python
 PIP := $(VENV_DIR)/bin/pip

--- a/docs/reference/variables-env.md
+++ b/docs/reference/variables-env.md
@@ -10,7 +10,7 @@ Le fichier `.env` centralise la configuration de l'ensemble des services. Voici 
 | `OLLAMA_IMAGE_MODEL` | `stable-diffusion` | Modèle de génération d'images. |
 | `OLLAMA_IMAGE_HOST` | `stablediffusion` | Hôte pour la génération d'images. |
 | `OLLAMA_IMAGE_PORT` | `7860` | Port du service d'images. |
-| `GODOT_PATH` | `./Godot_v4.x86_64` | Exécutable Godot utilisé par le `Makefile`. |
+| `GODOT_PATH` | `./Godot_v4.x86_64` | Exécutable Godot utilisé par le `Makefile`. Si absent, `godot4` est essayé. |
 | `DATABASE_URL` | `sqlite:///./data/game.db` | Chemin de la base de données. |
 | `NVIDIA_VISIBLE_DEVICES` | _(vide)_ | Active l'accélération GPU dans les conteneurs. |
 


### PR DESCRIPTION
## Summary
- load `.env` automatically in the Makefile
- fall back to `godot4` when `GODOT_PATH` isn't defined
- document this fallback in the env vars reference

## Testing
- `black backend/app`
- `.venv/bin/python -m pytest -q`
- `vale docs/` *(fails: 4 errors)*
- `.venv/bin/mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_684183d2ea08832e8edc7b97648e5329