### PR TITLE
🤖 Improve clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,13 @@ run-api: install ## ⚡ Lance l'API FastAPI en local
 
 clean: ## 🧹 Supprime fichiers temporaires / cache
 	@echo "\033[1;31m🗑 Nettoyage des fichiers temporaires...\033[0m"
-	rm -rf __pycache__ .pytest_cache */__pycache__ */*/__pycache__ *.pyc *.pyo
+	@find . -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null
+	@find . -name '*.py[cod]' -delete 2>/dev/null
+	@rm -rf .pytest_cache
+
+cleanall: clean ## 💥 Supprime caches et volumes Docker
+	@echo "\033[1;31m🗑 Suppression des volumes Docker...\033[0m"
+	docker compose down -v
 
 install: ## 📦 Crée le venv et installe les dépendances
 	@test -x $(PYTHON) || python3 -m venv $(VENV_DIR)

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -43,7 +43,7 @@ Cette page recense les erreurs les plus courantes et comment les résoudre.
 
 - Purgez les volumes et relancez :
   ```bash
-  make purge-models
+  make cleanall
   make up
   ```
 

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -4,6 +4,8 @@ Le `Makefile` centralise plusieurs commandes utiles :
 - `make up` lance tous les conteneurs via Docker Compose ;
 - `make down` arrête les conteneurs ;
 - `make rebuild` recrée les images Docker sans cache ;
+- `make clean` supprime les caches Python ;
+- `make cleanall` supprime aussi les volumes Docker pour repartir de zéro ;
 - `make purge-models` supprime les modèles enregistrés dans les volumes Docker ;
 - `make up-models` lance la stack en choisissant `MODEL_TEXT` et `MODEL_IMAGE`,
   puis affiche les noms retenus ;


### PR DESCRIPTION
## Summary
- handle pycache removal more robustly
- add `cleanall` to drop Docker volumes
- document cleanup commands in reference and troubleshooting guides

## Testing
- `pytest -q`
- `mkdocs build`
- `vale docs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684194ccb2f8832e8f2bb33e44d928f1