### PR TITLE
🤖 Update configuration reference

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,11 +2,13 @@
 
 Principales variables d'environnement :
 
-- `OLLAMA_HOST` : hôte du service Ollama (par défaut `ollama`).
-- `OLLAMA_PORT` : port d'écoute d'Ollama (`11434`).
+- `OLLAMA_TEXT_HOST` : hôte du service Ollama pour le texte (par défaut `ollama`).
+- `OLLAMA_TEXT_PORT` : port d'écoute d'Ollama pour le texte (`11434`).
+- `OLLAMA_IMAGE_HOST` : hôte du service de génération d'images (`stablediffusion`).
+- `OLLAMA_IMAGE_PORT` : port du service d'images (`7860`).
 - `OLLAMA_TEXT_MODEL` : modèle utilisé pour la génération de texte.
 - `OLLAMA_IMAGE_MODEL` : modèle pour la génération d'images.
-- `NVIDIA_VISIBLE_DEVICES` : permet d'activer le GPU dans le conteneur.
+- `NVIDIA_VISIBLE_DEVICES` : permet d'activer le GPU dans les conteneurs.
 
 Fichiers importants :
 


### PR DESCRIPTION
## Summary
- fix environment variable names in configuration documentation

## Testing
- `pytest -q`
- `mkdocs build`
- `vale --config=.vale.ini docs/` *(fails: Vale.Repetition errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841c5165b48832ebac6438bf38b8bd1