### PR TITLE
🤖 Update docs to match repo state

### DIFF
--- a/docs/explications/godot.md
+++ b/docs/explications/godot.md
@@ -28,7 +28,7 @@ func _send_to_llm(message: String):
 
 Pour lancer l'éditeur :
 ```bash
-make run-godot
+make godot
 ```
 
 ## Voir aussi

--- a/docs/explications/ollama.md
+++ b/docs/explications/ollama.md
@@ -2,11 +2,7 @@
 
 Ollama lance le modèle de langage à l'intérieur d'un conteneur Docker. Il télécharge
 le modèle choisi lors du premier démarrage (par exemple Mistral ou Llama 3).
-Ce téléchargement s'effectue automatiquement lorsque vous exécutez `make up` et
-le modèle reste ensuite disponible localement pour les démarrages suivants. La
-commande appelle d'abord `entrypoint_ollama.sh --download`,
-qui exécute `ollama pull` sur les modèles déclarés dans `.env` s'ils sont
-absents.
+Lorsque vous exécutez `make up`, le conteneur lance le script `entrypoint_ollama.sh` qui vérifie la présence des modèles et les télécharge automatiquement s'ils sont absents.
 
 Le processus est piloté par le script `entrypoint_ollama.sh` :
 1. Il démarre `ollama serve` en arrière-plan et attend que l'API réponde.

--- a/docs/guides/configurer-env.md
+++ b/docs/guides/configurer-env.md
@@ -9,7 +9,7 @@ Ce guide explique comment personnaliser les variables d'environnement de GodotAI
    make down
    make up
    ```
-   La commande téléchargera les modèles définis dans `.env` grâce à `entrypoint_ollama.sh --download` s'ils ne sont pas encore présents.
+   Les modèles seront téléchargés automatiquement par le conteneur Ollama s'ils ne sont pas encore présents.
 
 Pour utiliser le GPU, définissez `NVIDIA_VISIBLE_DEVICES=all` avant de lancer `make up`.
 

--- a/docs/reference/docker-compose-yml.md
+++ b/docs/reference/docker-compose-yml.md
@@ -1,12 +1,12 @@
 # 🐳 docker-compose.yml
 
-Ce fichier coordonne les conteneurs nécessaires au projet. Il définit trois services :
+Ce fichier coordonne les conteneurs nécessaires au projet. Il définit cinq services :
 - **fastapi** pour le backend Python ;
 - **ollama** pour la génération de texte et d’images, construit à partir du `Dockerfile.ollama` ;
-- **stablediffusion** pour l’interface Web de Stable Diffusion.
-
-Les volumes comme `ollama_models` et `sd_outputs` conservent les modèles et les résultats entre chaque exécution. Les variables d’environnement proviennent du fichier `.env` afin de personnaliser les ports ou les noms de modèle.
-
+- **stablediffusion** pour l’interface Web de Stable Diffusion ;
+- **postgres** pour la base relationnelle ;
+- **mongo** pour stocker les réponses complètes.
+Les volumes nommés, comme `ollama_models`, `sd_models` ou `postgres_data`, conservent les données entre chaque exécution. Les variables sont définies dans `.env`.
 En règle générale, `docker-compose.yml` permet de démarrer l’ensemble avec `docker compose up` ou la commande `make up` prévue dans le projet.
 
 ## Voir aussi

--- a/docs/reference/entrypoint-ollama.md
+++ b/docs/reference/entrypoint-ollama.md
@@ -10,8 +10,7 @@ Ce script s'exécute lorsque le conteneur Ollama démarre. Son rôle est de pré
 
 Grâce à cette séquence, on dispose d'un service prêt à répondre dès le premier `docker compose up`.
 
-Le même script peut être invoqué avec `--download` pour pré-télécharger les modèles avant le démarrage des services.
-Ce processus complet se déclenche automatiquement lors d'un `make up`.
+Ce script se charge automatiquement de télécharger les modèles lors du démarrage du conteneur.
 
 ## Voir aussi
 

--- a/docs/tutoriels/premiers-pas.md
+++ b/docs/tutoriels/premiers-pas.md
@@ -40,7 +40,7 @@ Suivez les étapes ci-dessous dans l'ordre pour déployer la stack complète.
    Pour plus de détails, consultez [test_services.py](../reference/test-services.md).
 6. (Optionnel) Lancez Godot :
    ```bash
-   make run-godot
+   make godot
    ```
 7. (Optionnel) Exécutez les tests unitaires et E2E :
    ```bash


### PR DESCRIPTION
## Summary
- fix instructions for launching Godot
- clarify model download process
- document all Docker services

## Testing
- `black backend/app`
- `.venv/bin/pytest -q`
- `mkdocs build`
- `vale docs/` (fails: 8 errors)

------
https://chatgpt.com/codex/tasks/task_e_6841c74de950832e96001fde22fe471d