### PR TITLE
🤖 Fix Godot headless Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ install: ## 📦 Crée le venv et installe les dépendances
 
 godot_api_call: ## 🧠 Appel API Godot en mode headless
 	@echo "🧠  Lancement d’un appel API Godot en mode headless..."
-	$(GODOT_PATH) --headless --path godot/ --script scripts/ChatUI.gd
+	$(GODOT_PATH) --headless --path godot/ --scene scenes/ChatScene.tscn
 
 generate-diagrams: ## 🖼️ Convertit les fichiers D2 en SVG
 	@if command -v d2 >/dev/null 2>&1; then \


### PR DESCRIPTION
## Summary
- fix the `godot_api_call` target to launch the scene in headless mode

## Testing
- `make godot_api_call` *(fails: `./Godot_v4.x86_64: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6841d526e668832ea15a23c317669bea