### PR TITLE
🤖 Split Stable Diffusion client

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from .embedding_context import EmbeddingContext
 from .ollama_client import generate_text as ollama_generate_text
-from .ollama_client import generate_image as ollama_generate_image
+from .stablediffusion_client import generate_image as stablediffusion_generate_image
 from .mcp import router as mcp_router
 from .mongo_database import get_mongo_db
 
@@ -78,7 +78,7 @@ STABLEDIFFUSION_HOST = settings.STABLEDIFFUSION_HOST
 STABLEDIFFUSION_PORT = str(settings.STABLEDIFFUSION_PORT)
 
 OLLAMA_TEXT_BASE_URL = f"http://{OLLAMA_TEXT_HOST}:{OLLAMA_TEXT_PORT}/api"
-OLLAMA_IMAGE_BASE_URL = f"http://{STABLEDIFFUSION_HOST}:{STABLEDIFFUSION_PORT}/api"
+STABLEDIFFUSION_BASE_URL = f"http://{STABLEDIFFUSION_HOST}:{STABLEDIFFUSION_PORT}/api"
 
 
 # Endpoint pour générer du texte via Ollama
@@ -95,7 +95,7 @@ def gen_text(req: ContextRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-# Endpoint pour générer une image via Ollama
+# Endpoint pour générer une image via Stable Diffusion
 @app.get("/img")
 def gen_image_get():
     # Chemin unique, car utils est monté dans /app/utils dans le conteneur Docker
@@ -113,7 +113,7 @@ def gen_image_get():
 @app.post("/img")
 def gen_image(req: ImageRequest):
     try:
-        return ollama_generate_image(req.prompt)
+        return stablediffusion_generate_image(req.prompt)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -134,7 +134,7 @@ def text_model(req: PromptRequest):
 def image_model(req: PromptRequest):
     """Generate an image using the Stable Diffusion container."""
     try:
-        return ollama_generate_image(req.prompt)
+        return stablediffusion_generate_image(req.prompt)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -226,7 +226,7 @@ def generate_text(req: GenerateTextRequest, db: Session = Depends(get_db)):
 @app.post("/generate-image")
 def generate_image(req: GenerateImageRequest, db: Session = Depends(get_db)):
     try:
-        data = ollama_generate_image(req.description)
+        data = stablediffusion_generate_image(req.description)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/ollama_client.py
+++ b/backend/app/ollama_client.py
@@ -7,7 +7,6 @@ import requests
 from .config import settings
 
 TEXT_BASE_URL = f"http://{settings.ollama_text_host}:{settings.ollama_text_port}/api"
-IMAGE_BASE_URL = f"http://{settings.STABLEDIFFUSION_HOST}:{settings.STABLEDIFFUSION_PORT}/api"
 
 
 def generate_text(prompt: str) -> dict:
@@ -15,16 +14,6 @@ def generate_text(prompt: str) -> dict:
     resp = requests.post(
         f"{TEXT_BASE_URL}/generate",
         json={"model": settings.ollama_text_model, "prompt": prompt},
-    )
-    resp.raise_for_status()
-    return resp.json()
-
-
-def generate_image(prompt: str) -> dict:
-    """Generate an image with the configured Stable Diffusion model."""
-    resp = requests.post(
-        f"{IMAGE_BASE_URL}/generate-image",
-        json={"model": settings.STABLEDIFFUSION_MODEL, "prompt": prompt},
     )
     resp.raise_for_status()
     return resp.json()

--- a/backend/app/stablediffusion_client.py
+++ b/backend/app/stablediffusion_client.py
@@ -1,0 +1,21 @@
+"""Client helpers for Stable Diffusion image generation."""
+
+from __future__ import annotations
+
+import requests
+
+from .config import settings
+
+IMAGE_BASE_URL = (
+    f"http://{settings.STABLEDIFFUSION_HOST}:{settings.STABLEDIFFUSION_PORT}/api"
+)
+
+
+def generate_image(prompt: str) -> dict:
+    """Generate an image with the configured Stable Diffusion model."""
+    resp = requests.post(
+        f"{IMAGE_BASE_URL}/generate-image",
+        json={"model": settings.STABLEDIFFUSION_MODEL, "prompt": prompt},
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/backend/tests/test_backend_server_endpoints.py
+++ b/backend/tests/test_backend_server_endpoints.py
@@ -21,7 +21,7 @@ def test_gen_text(monkeypatch):
 
     monkeypatch.setattr("backend.app.main.requests.post", fake_post)
 
-    resp = client.post("/gen_text", json={"context": "context"})
+    resp = client.post("/txt", json={"context": "context"})
     assert resp.status_code == 200
     assert resp.json() == {"response": "text"}
 
@@ -44,10 +44,10 @@ def test_list_models(monkeypatch):
 
 def test_generate_image(monkeypatch):
     monkeypatch.setattr(
-        "backend.app.main.ollama_generate_image",
+        "backend.app.main.stablediffusion_generate_image",
         lambda prompt: {"image": "imgdata"},
     )
 
-    resp = client.post("/gen_image", json={"prompt": "hello"})
+    resp = client.post("/img", json={"prompt": "hello"})
     assert resp.status_code == 200
     assert resp.json() == {"image": "imgdata"}

--- a/backend/tests/test_embedding.py
+++ b/backend/tests/test_embedding.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from backend.app.embedding_context import EmbeddingContext
-from backend.app.ollama_client import generate_image
+from backend.app.stablediffusion_client import generate_image
 
 from unittest.mock import Mock
 
@@ -31,6 +31,6 @@ def test_generate_image(monkeypatch):
         assert json["prompt"] == "a prompt"
         return mock_response
 
-    monkeypatch.setattr("backend.app.ollama_client.requests.post", fake_post)
+    monkeypatch.setattr("backend.app.stablediffusion_client.requests.post", fake_post)
     result = generate_image("a prompt")
     assert result == {"image": "data"}

--- a/backend/tests/test_root.py
+++ b/backend/tests/test_root.py
@@ -38,7 +38,7 @@ def test_text_endpoint(monkeypatch):
         return mock_resp
 
     monkeypatch.setattr("backend.app.main.requests.post", fake_post)
-    resp = client.post("/text", json={"prompt": "hi"})
+    resp = client.post("/txt", json={"context": "hi"})
     assert resp.status_code == 200
     assert resp.json()["response"] == "ok"
 
@@ -49,8 +49,8 @@ def test_image_endpoint(monkeypatch):
         return {"image": "imgdata"}
 
     monkeypatch.setattr(
-        "backend.app.main.ollama_generate_image", fake_generate
+        "backend.app.main.stablediffusion_generate_image", fake_generate
     )
-    resp = client.post("/image", json={"prompt": "draw"})
+    resp = client.post("/img", json={"prompt": "draw"})
     assert resp.status_code == 200
     assert resp.json()["image"] == "imgdata"

--- a/docs/explications/backend.md
+++ b/docs/explications/backend.md
@@ -32,9 +32,14 @@ sauvegardées dans MongoDB grâce au module
 de fournir un contexte lors des échanges avec le modèle de langage.
 
 ## ollama_client.py
-Ce module regroupe les appels HTTP nécessaires pour interroger Ollama pour le
-texte et les images. Il est invoqué par le serveur lorsqu'une scène du jeu doit
-être illustrée ou lorsqu'une réponse textuelle est nécessaire.
+Ce module regroupe les appels HTTP nécessaires pour interroger **Ollama** afin
+de générer du texte. Il est invoqué par le serveur lorsqu'une réponse
+conversationnelle est demandée.
+
+## stablediffusion_client.py
+Cette nouvelle unité se charge d'appeler **Stable Diffusion** pour produire les
+illustrations. Elle est isolée afin de ne plus mêler la logique de génération
+d'images avec celle du texte.
 
 ## config.py
 Toutes les variables de configuration (hôtes, ports, nom des modèles Ollama)


### PR DESCRIPTION
## Summary
- move image generation helpers into stablediffusion_client module
- keep ollama_client focused on text
- update imports, tests and docs accordingly

## Testing
- `black backend/app`
- `black backend/tests`
- `mkdocs build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e6ac0d78832eac7ef63be4b04e2f