### PR TITLE
🤖 Add FastAPI command and rebuild note

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - ./utils:/app/utils
       - ./data:/app/data
     env_file: .env
+    command: uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
     depends_on:
       - ollama
       - stablediffusion

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -21,6 +21,14 @@ Cette page recense les erreurs les plus courantes et comment les résoudre.
   docker compose logs -f
   ```
 
+## FastAPI ne trouve pas `backend.app.main`
+
+- Si les logs affichent `ModuleNotFoundError: No module named 'backend.app.main'`,
+  reconstruisez les images :
+  ```bash
+  make rebuild
+  ```
+
 ## Erreurs de dépendances Python
 
 - (Ré)installez les paquets :


### PR DESCRIPTION
## Summary
- ensure FastAPI container runs uvicorn
- document rebuild step when import fails

## Testing
- `docker compose build fastapi` *(fails: command not found)*
- `mkdocs build` *(fails: command not found)*
- `vale docs/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f44dc018832e91f85c0cd074a921