### PR TITLE
🤖 Harmonize API communication

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,24 +81,16 @@ OLLAMA_TEXT_BASE_URL = f"http://{OLLAMA_TEXT_HOST}:{OLLAMA_TEXT_PORT}/api"
 STABLEDIFFUSION_BASE_URL = f"http://{STABLEDIFFUSION_HOST}:{STABLEDIFFUSION_PORT}/api"
 
 
-# Endpoint pour générer du texte via Ollama
+# Example GET endpoints
 @app.get("/txt")
 def gen_text_get():
+    """Simple ping for the text route."""
     return {"text": "hello world"}
 
 
-@app.post("/txt")
-def gen_text(req: ContextRequest):
-    try:
-        return ollama_generate_text(req.context)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-# Endpoint pour générer une image via Stable Diffusion
 @app.get("/img")
 def gen_image_get():
-    # Chemin unique, car utils est monté dans /app/utils dans le conteneur Docker
+    """Return a sample image shipped with the container."""
     image_path = "/app/utils/img/image.png"
     try:
         with open(image_path, "rb") as img_file:
@@ -110,15 +102,7 @@ def gen_image_get():
         )
 
 
-@app.post("/img")
-def gen_image(req: ImageRequest):
-    try:
-        return stablediffusion_generate_image(req.prompt)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-# --- Simple endpoints for direct model access --- #
+# --- Endpoints calling the Docker services --- #
 
 
 @app.post("/txt")

--- a/backend/app/ollama_client.py
+++ b/backend/app/ollama_client.py
@@ -13,7 +13,6 @@ IMAGE_BASE_URL = (
 )
 
 
-
 def generate_text(prompt: str) -> dict:
     """Generate text with the configured Ollama model."""
     resp = requests.post(

--- a/backend/tests/test_backend_server_endpoints.py
+++ b/backend/tests/test_backend_server_endpoints.py
@@ -19,9 +19,12 @@ def test_gen_text(monkeypatch):
         resp.json.return_value = {"response": "text"}
         return resp
 
-    monkeypatch.setattr("backend.app.main.requests.post", fake_post)
+    monkeypatch.setattr(
+        "backend.app.ollama_client.requests.post",
+        fake_post,
+    )
 
-    resp = client.post("/txt", json={"context": "context"})
+    resp = client.post("/txt", json={"prompt": "context"})
     assert resp.status_code == 200
     assert resp.json() == {"response": "text"}
 

--- a/backend/tests/test_root.py
+++ b/backend/tests/test_root.py
@@ -37,9 +37,12 @@ def test_text_endpoint(monkeypatch):
         assert json["prompt"] == "hi"
         return mock_resp
 
-    monkeypatch.setattr("backend.app.main.requests.post", fake_post)
+    monkeypatch.setattr(
+        "backend.app.ollama_client.requests.post",
+        fake_post,
+    )
 
-    resp = client.post("/txt", json={"context": "hi"})
+    resp = client.post("/txt", json={"prompt": "hi"})
 
     assert resp.status_code == 200
     assert resp.json()["response"] == "ok"


### PR DESCRIPTION
## Summary
- refactor `/txt` and `/img` endpoints to use shared request model
- update tests for new request structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842d4c28f48832e94bd6595b8acaf18