### PR TITLE
🤖 Ensure .env values are loaded

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,9 @@
 from pydantic import BaseSettings
+from dotenv import load_dotenv, find_dotenv
+
+# Ensure environment variables from the project's .env file are loaded so that
+# modules using `os.getenv` have access to them as well.
+load_dotenv(find_dotenv())
 
 
 class Settings(BaseSettings):
@@ -11,7 +16,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_prefix = ""
-        env_file = ".env"
+        env_file = find_dotenv()
         case_sensitive = False
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,10 @@
+import os
+from importlib import reload
+
+import backend.app.config as config
+
+
+def test_env_loaded():
+    reload(config)  # ensure dotenv is loaded
+    assert config.settings.ollama_text_model == "smollm:latest"
+    assert os.getenv("OLLAMA_TEXT_MODEL") == "smollm:latest"


### PR DESCRIPTION
## Summary
- load environment variables using `python-dotenv`
- expose `.env` to `BaseSettings`
- test that configuration loads `.env` variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842d86ada0c832e9ffea45eaa5e537f