### PR TITLE
🤖 Improve /txt relay

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,10 +45,8 @@ class ImageRequest(BaseModel):
 
 
 class PromptRequest(BaseModel):
-    model: str
     prompt: str
     stream: bool = False
-
 
 
 class GenerateImageRequest(BaseModel):
@@ -110,10 +108,9 @@ def gen_image_get():
 
 @app.post("/txt")
 def text_model(req: PromptRequest):
-    print("Coucou je suis ta requete de fastapi: {req}")
     """Generate text using the Ollama container."""
     try:
-        return ollama_generate_text(req.prompt)
+        return ollama_generate_text(req.prompt, req.stream)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/ollama_client.py
+++ b/backend/app/ollama_client.py
@@ -13,12 +13,11 @@ IMAGE_BASE_URL = (
 )
 
 
-def generate_text(prompt: str) -> dict:
+def generate_text(prompt: str, stream: bool = False) -> dict:
     """Generate text with the configured Ollama model."""
-    print("Prompt from ollama client:", prompt)
     resp = requests.post(
         f"{TEXT_BASE_URL}/generate",
-        json={"model": settings.ollama_text_model, "prompt": prompt, "stream": True},
+        json={"model": settings.ollama_text_model, "prompt": prompt, "stream": stream},
     )
     resp.raise_for_status()
     return resp.json()


### PR DESCRIPTION
## Summary
- simplify `PromptRequest` to only need `prompt` and optional `stream`
- forward stream option when relaying to Ollama

## Testing
- `black backend/app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e11ff48c832e83b261e72e3d6c87