### PR TITLE
🤖 Implement streaming with WebSocket

### DIFF
--- a/backend/tests/test_mongo.py
+++ b/backend/tests/test_mongo.py
@@ -1,8 +1,10 @@
 import os
 import sys
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from backend.app.mongo_database import get_mongo_db
 from pymongo.database import Database
+
 
 def test_get_mongo_db():
     db = get_mongo_db()

--- a/backend/tests/test_websocket_stream.py
+++ b/backend/tests/test_websocket_stream.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+async def fake_stream_text(prompt: str):
+    yield '{"response": "foo"}'
+    yield '{"response": "bar"}'
+
+
+def test_websocket_stream(monkeypatch):
+    monkeypatch.setattr("backend.app.main.ollama_stream_text", fake_stream_text)
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_json({"prompt": "hi"})
+        first = websocket.receive_text()
+        second = websocket.receive_text()
+        done = websocket.receive_text()
+    assert first == '{"response": "foo"}'
+    assert second == '{"response": "bar"}'
+    assert done == "[DONE]"

--- a/godot/scripts/ChatUI.gd
+++ b/godot/scripts/ChatUI.gd
@@ -4,21 +4,17 @@ extends Control
 @onready var input_box: LineEdit = $GridContainer/BottomLeft/BoxContainer/HBoxContainer/InputBox
 @onready var send_button: Button = $GridContainer/BottomLeft/BoxContainer/HBoxContainer/SendButton
 
-var http := HTTPRequest.new()
-var stream_timer := Timer.new()
-var stream_buffer := ""
-var stream_lines := []
-var line_index := 0
+var websocket := WebSocketClient.new()
 var is_streaming := false
 
 func _ready():
-	# print_tree_pretty()
-	add_child(http)
-	add_child(stream_timer)
-	stream_timer.one_shot = false
-	stream_timer.wait_time = 0.05
-	stream_timer.timeout.connect(_on_stream_timer_timeout)
-	http.request_completed.connect(_on_result)
+        var err = websocket.connect_to_url("ws://localhost:8000/ws")
+        if err != OK:
+                printerr("[ChatUI] WebSocket connection failed: %s" % err)
+        websocket.connect("connection_established", Callable(self, "_on_ws_connected"))
+        websocket.connect("connection_error", Callable(self, "_on_ws_error"))
+        websocket.connect("connection_closed", Callable(self, "_on_ws_closed"))
+        websocket.connect("data_received", Callable(self, "_on_ws_data"))
 	
 	if is_instance_valid(input_box):
 		input_box.text_submitted.connect(_on_send_pressed)
@@ -35,55 +31,49 @@ func _ready():
 		printerr("[ChatUI] chat_history n'est pas instancié !")
 
 func _on_send_pressed(_event: Variant = null):
-	if is_streaming or input_box.text.strip_edges() == "":
-		return
-	var user_message = input_box.text.strip_edges()
-	_append_message("Vous", user_message)
-	input_box.text = ""
-	_send_to_llm(user_message)
+        if is_streaming or input_box.text.strip_edges() == "":
+                return
+        var user_message = input_box.text.strip_edges()
+        _append_message("Vous", user_message)
+        input_box.text = ""
+        _send_to_llm(user_message)
 
 func _send_to_llm(message: String):
-	var url := "http://localhost:8000/txt"
-	var body := {
-		"prompt": message,
-		"stream": false,
-	}
-	var headers := ["Content-Type: application/json"]
-	var err := http.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(body))
-	if err != OK:
-		_append_message("Assistant", "[Erreur réseau]")
-	else:
-		stream_buffer = ""
-		stream_lines.clear()
-		line_index = 0
-		is_streaming = true
+        if websocket.get_connection_status() != WebSocketClient.CONNECTION_CONNECTED:
+                _append_message("Assistant", "[WebSocket non connecté]")
+                return
+        var body := {"prompt": message}
+        websocket.get_peer(1).put_packet(JSON.stringify(body).to_utf8())
+        is_streaming = true
 
-func _on_result(_result, _code, _headers, body):
-	stream_buffer = body.get_string_from_utf8()
-	stream_lines = stream_buffer.split("\n")
-	line_index = 0
-	stream_timer.start()
+func _on_ws_connected(protocol: String) -> void:
+        pass
 
-func _on_stream_timer_timeout():
-	if line_index >= stream_lines.size():
-		stream_timer.stop()
-		is_streaming = false
-		_append_message("Assistant", chat_history.text.split("Assistant: ")[-1])
-		return
+func _on_ws_error() -> void:
+        printerr("[ChatUI] WebSocket connection error")
 
-	var line = stream_lines[line_index].strip_edges()
-	line_index += 1
-	if line == "":
-		return
+func _on_ws_closed(was_clean: bool) -> void:
+        printerr("[ChatUI] WebSocket closed")
 
-	var json := JSON.new()
-	if json.parse(line) == OK:
-		var token := str(json.data.get("response", ""))
-		if is_instance_valid(chat_history):
-			var current = chat_history.text.split("Assistant: ")[-1]
-			chat_history.text = _format_chat("Assistant", current + token)
-	else:
-		printerr("Erreur parsing ligne: ", line)
+func _on_ws_data() -> void:
+        while websocket.get_peer(1).get_available_packet_count() > 0:
+                var line = websocket.get_peer(1).get_packet().get_string_from_utf8().strip_edges()
+                if line == "[DONE]":
+                        is_streaming = false
+                        _append_message("Assistant", chat_history.text.split("Assistant: ")[-1])
+                        continue
+                var json := JSON.new()
+                if json.parse(line) == OK:
+                        var token := str(json.data.get("response", ""))
+                        if is_instance_valid(chat_history):
+                                var current = chat_history.text.split("Assistant: ")[-1]
+                                chat_history.text = _format_chat("Assistant", current + token)
+                else:
+                        printerr("Erreur parsing ligne: ", line)
+
+func _process(delta: float) -> void:
+        if websocket.get_connection_status() != WebSocketClient.CONNECTION_DISCONNECTED:
+                websocket.poll()
 
 func _append_message(who: String, msg: String):
 	chat_history.append_text("%s: %s\n" % [who, msg])


### PR DESCRIPTION
## Summary
- add async stream_text helper using httpx
- enable text endpoint streaming and new WebSocket route
- display stream in ChatUI via WebSocketClient
- cover WebSocket endpoint with tests

## Testing
- `black backend/app backend/tests`
- `pytest -q`
- `mkdocs build`
- `vale docs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f25179d0832e914b5221ff60502a