### PR TITLE
🤖 Update docs for new API endpoints

### DIFF
--- a/docs/explications/architecture.md
+++ b/docs/explications/architecture.md
@@ -8,7 +8,7 @@ Le diagramme ci-dessous est généré en SVG avec **D2** :
 
 ## Rôle des composants
 - **Godot 🎮** : le dossier `godot/` renferme les scènes et scripts du mini-jeu. La scène `scenes/Main.tscn` communique avec l'API via des nœuds `HTTPRequest`.
-- **FastAPI ⚡** : le backend Python vit dans `backend/app`. Le module `main.py` expose notamment la route `/generate-text` et enregistre les échanges dans `data/game.db` grâce à SQLAlchemy.
+ - **FastAPI ⚡** : le backend Python vit dans `backend/app`. Le module `main.py` expose notamment la route `/txt` et enregistre les échanges dans `data/game.db` grâce à SQLAlchemy.
 - **Ollama 🦙** : construit via `Dockerfile.ollama`, ce service télécharge le modèle indiqué par `OLLAMA_TEXT_MODEL` au démarrage grâce au script `entrypoint_ollama.sh`.
 - **Stable Diffusion 🎨** : le service `stablediffusion` gère la génération d'images et conserve les fichiers dans les volumes `sd_models` et `sd_outputs`.
 - **Docker Compose 🐳** : le fichier `docker-compose.yml` orchestre tous les conteneurs et le `Makefile` fournit les raccourcis `make up` et `make down`.
@@ -29,10 +29,10 @@ Chaque page de la documentation renvoie vers le site officiel et le manuel de r�
 import requests
 
 BASE_URL = "http://localhost:8000"
-resp = requests.post(
-    f"{BASE_URL}/generate-text",
-    json={"session_id": 1, "action": "look around"},
-)
+    resp = requests.post(
+        f"{BASE_URL}/txt",
+        json={"prompt": "look around", "stream": False},
+    )
 print(resp.json())
 ```
 

--- a/docs/explications/godot.md
+++ b/docs/explications/godot.md
@@ -2,7 +2,7 @@
 
 Godot est un moteur de jeu libre et léger. Dans ce projet, il fournit l'interface
 graphique du mini-jeu et communique avec l'API Python.
-Les scripts GDScript appellent l'endpoint `/generate-text` pour afficher les réponses du modèle.
+Les scripts GDScript appellent l'endpoint `/txt` pour afficher les réponses du modèle.
 Chaque zone de l'écran est un panneau pouvant être déplacé grâce au script `DraggablePanel.gd`.
 
 Quand le joueur effectue une action, ces scripts envoient la requête à FastAPI
@@ -14,11 +14,11 @@ Extrait de la fonction d'envoi d'un message au modèle :
 
 ```gdscript
 func _send_to_llm(message: String):
-    var url := "http://localhost:11434/api/generate"
+    var url := "http://localhost:8000/txt"
     var body := {
         "model": "god:latest",
         "prompt": message,
-        "stream": true
+        "stream": false
     }
     var headers := ["Content-Type: application/json"]
     var err := http.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(body))

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,17 @@ Cette documentation suit le cadre [Diátaxis](https://diataxis.fr/) et se divise
 - 🛠️ [Makefile](reference/makefile.md)
 - 🐳 [docker-compose.yml](reference/docker-compose-yml.md)
 - 📄 [Dockerfile.fastapi](reference/dockerfile.md)
+- 🐋 [Dockerfile.ollama](reference/dockerfile-ollama.md)
+- 🔧 [entrypoint_ollama.sh](reference/entrypoint-ollama.md)
+- 🗒️ [Modelfile](reference/modelfile.md)
+- 📜 [mkdocs.yml](reference/mkdocs-yml.md)
+- 📑 [variables d'environnement](reference/variables-env.md)
+- 📝 [AGENTS.md](reference/agents-file.md)
+- 🙈 [.gitignore](reference/gitignore.md)
 - ✅ [Tests unitaires](reference/tests-unitaires.md)
+- 🚦 [Tests E2E](reference/tests-e2e.md)
+- 🛠️ [test_services.py](reference/test-services.md)
+- 🔍 [Vale](reference/vale.md)
 
 ### 🧩 Explications
 - 🏗️ [Architecture](explications/architecture.md)

--- a/docs/reference/api-backend.md
+++ b/docs/reference/api-backend.md
@@ -3,17 +3,15 @@
 | Méthode | Endpoint | Description |
 |---------|----------|-------------|
 | GET | `/` | Vérifie que le backend fonctionne |
-| POST | `/gen_text` | Génère du texte à partir d'un contexte |
-| GET | `/gen_image` | Retourne une image d'exemple |
-| POST | `/gen_image` | Génère une image via Ollama |
-| POST | `/txt` | Appelle directement Ollama pour générer du texte |
-| POST | `/img` | Appelle Stable Diffusion pour générer une image |
+| GET | `/txt` | Test de connexion pour la route texte |
+| POST | `/txt` | Génère du texte via Ollama |
+| GET | `/img` | Retourne une image d'exemple |
+| POST | `/img` | Génère une image via Stable Diffusion |
 | GET | `/list_models` | Liste les modèles disponibles |
 | POST | `/users` | Crée un utilisateur |
 | POST | `/sessions` | Crée une session de jeu |
 | GET | `/sessions/{id}` | Récupère une session |
-| POST | `/generate-text` | Génère une réponse dans la session |
-| POST | `/generate-image` | Génère une image et l'enregistre |
+| POST | `/mcp` | Endpoint JSON-RPC MCP |
 
 
 L'API démarre automatiquement avec les autres services :


### PR DESCRIPTION
## Summary
- include every reference page in `docs/index.md`
- document current endpoints in API reference
- update architecture and Godot explanations

## Testing
- `black backend/app`
- `pytest -q` *(fails: ModuleNotFoundError for httpx, requests, pymongo)*
- `mkdocs build` *(fails: command not found)*
- `vale docs/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f928a030832ebcaf6a5e2689edae