### PR TITLE
🤖 Build God model in Ollama

### DIFF
--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -5,6 +5,10 @@ FROM ollama/ollama:latest
 # Installer outils utiles
 RUN apt-get update && apt-get install -y curl pciutils && rm -rf /var/lib/apt/lists/*
 
+# Copier le Modelfile et construire le modèle "god"
+COPY Modelfile /Modelfile
+RUN /bin/ollama create god -f /Modelfile
+
 # Définir la variable d'environnement (modifiable via compose)
 ENV OLLAMA_LLM_LIBRARY=cuda
 

--- a/docs/explications/architecture.md
+++ b/docs/explications/architecture.md
@@ -9,7 +9,7 @@ Le diagramme ci-dessous est généré en SVG avec **D2** :
 ## Rôle des composants
 - **Godot 🎮** : le dossier `godot/` renferme les scènes et scripts du mini-jeu. La scène `scenes/Main.tscn` communique avec l'API via des nœuds `HTTPRequest`.
  - **FastAPI ⚡** : le backend Python vit dans `backend/app`. Le module `main.py` expose notamment la route `/txt` et enregistre les échanges dans `data/game.db` grâce à SQLAlchemy.
-- **Ollama 🦙** : construit via `Dockerfile.ollama`, ce service télécharge le modèle indiqué par `OLLAMA_TEXT_MODEL` au démarrage grâce au script `entrypoint_ollama.sh`.
+ - **Ollama 🦙** : construit via `Dockerfile.ollama`, ce service crée le modèle `god` à partir du `Modelfile` puis télécharge au besoin le modèle indiqué par `OLLAMA_TEXT_MODEL` grâce au script `entrypoint_ollama.sh`.
 - **Stable Diffusion 🎨** : le service `stablediffusion` gère la génération d'images et conserve les fichiers dans les volumes `sd_models` et `sd_outputs`.
 - **Docker Compose 🐳** : le fichier `docker-compose.yml` orchestre tous les conteneurs et le `Makefile` fournit les raccourcis `make up` et `make down`.
 - **MkDocs 📚** : la documentation statique est générée depuis `docs/` à l'aide du fichier `mkdocs.yml`.

--- a/docs/explications/ollama.md
+++ b/docs/explications/ollama.md
@@ -18,6 +18,12 @@ Le fichier `Modelfile` à la racine du dépôt indique quel modèle charger. Fas
 lui envoie les requêtes de l'utilisateur pour obtenir une réponse adaptée à la
 partie en cours.
 
+Lors de la construction de l'image, cette configuration est transformée en un modèle nommé `god` via :
+
+```bash
+ollama create god -f /Modelfile
+```
+
 ## Voir aussi
 
 - [Fichier `Modelfile`](../reference/modelfile.md)

--- a/docs/reference/dockerfile-ollama.md
+++ b/docs/reference/dockerfile-ollama.md
@@ -1,13 +1,17 @@
 # 🐋 Dockerfile.ollama
 
-Basé sur l’image officielle `ollama/ollama`, ce Dockerfile ajoute quelques outils pratiques comme `curl` et `pciutils`. Il copie surtout le script `entrypoint_ollama.sh` qui gère le téléchargement automatique des modèles.
+Basé sur l’image officielle `ollama/ollama`, ce Dockerfile ajoute quelques outils pratiques comme `curl` et `pciutils`. Il intègre également le `Modelfile` pour construire le modèle personnalisé `god` et copie le script `entrypoint_ollama.sh` qui gère le téléchargement automatique des modèles.
 
 ```
 FROM ollama/ollama:latest
 RUN apt-get update && apt-get install -y curl pciutils
+COPY Modelfile /Modelfile
+RUN /bin/ollama create god -f /Modelfile
 COPY entrypoint_ollama.sh /entrypoint_ollama.sh
 ENTRYPOINT ["/entrypoint_ollama.sh"]
 ```
+
+Le `Modelfile` est donc empaqueté puis transformé en modèle local grâce à la commande `ollama create god -f /Modelfile`. Ce modèle nommé `god` est ensuite disponible pour l’interface Godot.
 
 L’entrée `ENTRYPOINT` lance ce script pour s’assurer que les modèles précisés sont bien présents avant d’exposer l’API Ollama.
 

--- a/docs/reference/modelfile.md
+++ b/docs/reference/modelfile.md
@@ -16,6 +16,12 @@ La directive `FROM` choisit la base du modèle. Les lignes `PARAMETER` ajustent 
 
 Ce fichier est copié dans l'image Ollama construite via `Dockerfile.ollama`. En le modifiant, on peut changer de modèle ou personnaliser l'expérience de jeu.
 
+Lors de la construction de l'image, la commande suivante génère le modèle local :
+
+```bash
+ollama create god -f /Modelfile
+```
+
 ## Voir aussi
 
 - [Guide pour adapter le prompt](../guides/adapter-prompt.md)


### PR DESCRIPTION
## Summary
- build the `god` model inside `Dockerfile.ollama`
- document the `ollama create` step
- clarify architecture and Ollama docs

## Testing
- `vale docs/`
- `mkdocs build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684300c5f240832e8864d5e3e4ea66aa