### PR TITLE
🤖 Build model inside volume

### DIFF
--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -5,6 +5,9 @@ FROM ollama/ollama:latest
 # Installer outils utiles
 RUN apt-get update && apt-get install -y curl pciutils && rm -rf /var/lib/apt/lists/*
 
+# Copier le Modelfile pour créer le modèle "god" au démarrage
+COPY Modelfile /Modelfile
+
 # Définir la variable d'environnement (modifiable via compose)
 ENV OLLAMA_LLM_LIBRARY=cuda
 

--- a/docs/explications/architecture.md
+++ b/docs/explications/architecture.md
@@ -9,7 +9,7 @@ Le diagramme ci-dessous est généré en SVG avec **D2** :
 ## Rôle des composants
 - **Godot 🎮** : le dossier `godot/` renferme les scènes et scripts du mini-jeu. La scène `scenes/Main.tscn` communique avec l'API via des nœuds `HTTPRequest`.
  - **FastAPI ⚡** : le backend Python vit dans `backend/app`. Le module `main.py` expose notamment la route `/txt` et enregistre les échanges dans `data/game.db` grâce à SQLAlchemy.
-- **Ollama 🦙** : construit via `Dockerfile.ollama`, ce service télécharge le modèle indiqué par `OLLAMA_TEXT_MODEL` au démarrage grâce au script `entrypoint_ollama.sh`.
+ - **Ollama 🦙** : construit via `Dockerfile.ollama`, ce service crée le modèle `god` à partir du `Modelfile` puis télécharge au besoin le modèle indiqué par `OLLAMA_TEXT_MODEL` grâce au script `entrypoint_ollama.sh`.
 - **Stable Diffusion 🎨** : le service `stablediffusion` gère la génération d'images et conserve les fichiers dans les volumes `sd_models` et `sd_outputs`.
 - **Docker Compose 🐳** : le fichier `docker-compose.yml` orchestre tous les conteneurs et le `Makefile` fournit les raccourcis `make up` et `make down`.
 - **MkDocs 📚** : la documentation statique est générée depuis `docs/` à l'aide du fichier `mkdocs.yml`.

--- a/docs/explications/ollama.md
+++ b/docs/explications/ollama.md
@@ -18,6 +18,18 @@ Le fichier `Modelfile` à la racine du dépôt indique quel modèle charger. Fas
 lui envoie les requêtes de l'utilisateur pour obtenir une réponse adaptée à la
 partie en cours.
 
+Au premier lancement du conteneur, `entrypoint_ollama.sh` crée un modèle local
+nommé `god` à partir de ce fichier :
+
+```bash
+ollama serve &
+until curl -s http://127.0.0.1:11434/api/tags > /dev/null; do sleep 1; done
+ollama create god -f /Modelfile
+kill $!
+```
+Le modèle est stocké dans le volume `ollama_models` pour éviter de nouveaux
+téléchargements.
+
 ## Voir aussi
 
 - [Fichier `Modelfile`](../reference/modelfile.md)

--- a/docs/reference/dockerfile-ollama.md
+++ b/docs/reference/dockerfile-ollama.md
@@ -1,13 +1,16 @@
 # 🐋 Dockerfile.ollama
 
-Basé sur l’image officielle `ollama/ollama`, ce Dockerfile ajoute quelques outils pratiques comme `curl` et `pciutils`. Il copie surtout le script `entrypoint_ollama.sh` qui gère le téléchargement automatique des modèles.
+Basé sur l’image officielle `ollama/ollama`, ce Dockerfile ajoute quelques outils pratiques comme `curl` et `pciutils`. Il intègre également le `Modelfile` copié dans l'image et le script `entrypoint_ollama.sh` qui gère la création du modèle personnalisé `god` ainsi que le téléchargement automatique des autres modèles.
 
 ```
 FROM ollama/ollama:latest
 RUN apt-get update && apt-get install -y curl pciutils
+COPY Modelfile /Modelfile
 COPY entrypoint_ollama.sh /entrypoint_ollama.sh
 ENTRYPOINT ["/entrypoint_ollama.sh"]
 ```
+
+Le `Modelfile` est embarqué dans l'image. Lors du premier démarrage, `entrypoint_ollama.sh` utilise ce fichier pour générer le modèle local `god` dans le volume `ollama_models`.
 
 L’entrée `ENTRYPOINT` lance ce script pour s’assurer que les modèles précisés sont bien présents avant d’exposer l’API Ollama.
 

--- a/docs/reference/entrypoint-ollama.md
+++ b/docs/reference/entrypoint-ollama.md
@@ -3,14 +3,13 @@
 Ce script s'exécute lorsque le conteneur Ollama démarre. Son rôle est de préparer l'environnement avant d'exposer l'API.
 
 1. Lancement de `ollama serve` en arrière‑plan.
-2. Vérification de la présence des modèles spécifiés dans `OLLAMA_TEXT_MODEL` et `STABLEDIFFUSION_MODEL`.
-3. Téléchargement automatique via `ollama pull` si un modèle manque.
-4. Affichage d'une barre de progression pour suivre l'avancement.
-5. Attente bloquante tant que `ollama serve` est actif.
+2. Création du modèle local `god` à partir du `Modelfile` si nécessaire.
+3. Vérification de la présence des modèles spécifiés dans `OLLAMA_TEXT_MODEL` et `STABLEDIFFUSION_MODEL`.
+4. Téléchargement automatique via `ollama pull` si un modèle manque.
+5. Affichage d'une barre de progression pour suivre l'avancement.
+6. Attente bloquante tant que `ollama serve` est actif.
 
-Grâce à cette séquence, on dispose d'un service prêt à répondre dès le premier `docker compose up`.
-
-Ce script se charge automatiquement de télécharger les modèles lors du démarrage du conteneur.
+Grâce à cette séquence, le modèle `god` est stocké dans le volume `ollama_models` et le service est prêt à répondre dès le premier `docker compose up`.
 
 ## Voir aussi
 

--- a/docs/reference/modelfile.md
+++ b/docs/reference/modelfile.md
@@ -16,6 +16,15 @@ La directive `FROM` choisit la base du modèle. Les lignes `PARAMETER` ajustent 
 
 Ce fichier est copié dans l'image Ollama construite via `Dockerfile.ollama`. En le modifiant, on peut changer de modèle ou personnaliser l'expérience de jeu.
 
+Lors du premier démarrage du conteneur, la commande suivante génère le modèle local :
+
+```bash
+ollama serve &
+until curl -s http://127.0.0.1:11434/api/tags > /dev/null; do sleep 1; done
+ollama create god -f /Modelfile
+kill $!
+```
+
 ## Voir aussi
 
 - [Guide pour adapter le prompt](../guides/adapter-prompt.md)

--- a/entrypoint_ollama.sh
+++ b/entrypoint_ollama.sh
@@ -11,6 +11,19 @@ PORT=${OLLAMA_PORT:-11434}
 MODELS=""
 [ -n "$OLLAMA_TEXT_MODEL" ] && MODELS="$MODELS $OLLAMA_TEXT_MODEL"
 
+# Créer un modèle local à partir d'un Modelfile
+create_local_model() {
+  NAME="$1"
+  FILE="$2"
+  [ -z "$NAME" ] && return
+  if /bin/ollama list | grep -qw "$NAME"; then
+    echo "✔️ Modèle '$NAME' déjà présent."
+  else
+    echo "🔨 Construction du modèle local '$NAME'..."
+    /bin/ollama create "$NAME" -f "$FILE"
+  fi
+}
+
 # Fonction de téléchargement de modèle
 pull_model_container() {
   MODEL_NAME="$1"
@@ -51,6 +64,9 @@ echo "Waiting for Ollama daemon to be ready..."
 until curl -s "http://127.0.0.1:$PORT/api/tags" > /dev/null; do
   sleep 1
 done
+
+# Construire le modèle depuis le Modelfile s'il n'est pas présent
+create_local_model god /Modelfile
 
 for MODEL in $MODELS; do
   pull_model_container "$MODEL"


### PR DESCRIPTION
## Summary
- create the `god` model at container startup so it persists in `ollama_models`
- adjust Dockerfile to only copy the `Modelfile`
- explain the runtime creation in docs

## Testing
- `black backend/app`
- `pytest -q` *(fails: ModuleNotFoundError: httpx, requests, pymongo)*
- `vale docs/` *(command not found)*
- `mkdocs build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684300c5f240832e8864d5e3e4ea66aa